### PR TITLE
bayes: move params_out to specs, cut calc_DO_fun

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: streamMetabolizer
 Type: Package
 Title: Estimate Stream Metabolism from Dissolved Oxygen Data
-Version: 0.3.11
-Date: 2015-09-07
+Version: 0.3.12
+Date: 2015-09-08
 Author: Alison Appling, Jordan Read, Luke Winslow, Bob Hall
 Maintainer: Alison Appling <aappling@usgs.gov>
 Description: Modeling package for stream metabolism.

--- a/R/plot_DO_preds.R
+++ b/R/plot_DO_preds.R
@@ -19,7 +19,7 @@ plot_DO_preds <- function(DO_preds, plot_as=c('both','conc','pctsat')) {
   
   plot_as <- match.arg(plot_as)
   
-  DO.mod <- '.ggplot.var'
+  var <- DO.mod <- '.ggplot.var'
   g <- switch(
     plot_as,
     'conc'={

--- a/R/specs_bayes_jags_nopool_obserr.R
+++ b/R/specs_bayes_jags_nopool_obserr.R
@@ -13,7 +13,6 @@ specs_bayes_jags_nopool_obserr <- function(
   
   # model setup (model_path will be added in metab_bayes)
   model_file = 'jags/nopool_obserr.txt',
-  calc_DO_fun = calc_DO_mod_by_diff,
   bayes_fun = 'bayes_1ply',
   bayes_software = 'jags',
   
@@ -32,6 +31,7 @@ specs_bayes_jags_nopool_obserr <- function(
   priors = FALSE,
   
   # inheritParams runjags_bayes
+  params_out = c("GPP.daily", "ER.daily", "K600.daily", "err.obs.sigma"),
   max_cores = 4, 
   adapt_steps = 100, 
   burnin_steps = 40, 
@@ -42,7 +42,6 @@ specs_bayes_jags_nopool_obserr <- function(
   
   list(
     model_file = model_file,
-    calc_DO_fun = calc_DO_fun,
     bayes_fun = bayes_fun,
     bayes_software = bayes_software,
     
@@ -58,6 +57,7 @@ specs_bayes_jags_nopool_obserr <- function(
     
     priors = priors,
     
+    params_out = params_out,
     max_cores = max_cores, 
     adapt_steps = adapt_steps, 
     burnin_steps = burnin_steps, 

--- a/R/specs_bayes_jags_nopool_procobserr.R
+++ b/R/specs_bayes_jags_nopool_procobserr.R
@@ -14,10 +14,6 @@
 #'   MCMC software package is used. The file name (in this case 
 #'   \code{"metab_bayes_simple.txt"}) will determine not only the model file to 
 #'   use but also which variables are packaged and sent to the MCMC software.
-#' @param calc_DO_fun function with which DO should be re-predicted from the 
-#'   fitted coefficients, probably either \code{calc_DO_mod} or 
-#'   \code{calc_DO_mod_by_diff}. The default value is set to match the default
-#'   value of \code{model_file} in each \code{specs_bayes} function.
 #' @param bayes_fun character in \code{c('bayes_1ply', 'bayes_all')} indicating 
 #'   whether the data should be split into daily chunks first ('bayes_1ply') or 
 #'   passed to the model fitting function in one big chunk ('bayes_all')
@@ -58,7 +54,6 @@ specs_bayes_jags_nopool_procobserr <- function(
   
   # model setup (model_path will be added in metab_bayes)
   model_file = 'jags/nopool_procobserr.txt',
-  calc_DO_fun = calc_DO_mod,
   bayes_fun = 'bayes_1ply',
   bayes_software = 'jags',
   
@@ -73,7 +68,7 @@ specs_bayes_jags_nopool_procobserr <- function(
   err.proc.phi.min = 0,
   err.proc.phi.max = 1,
   err.proc.sigma.min = 0,
-  err.proc.sigma.max = 0.005,
+  err.proc.sigma.max = 0.0005,
   err.obs.sigma.min = 0,
   err.obs.sigma.max = 0.5,
   
@@ -81,6 +76,7 @@ specs_bayes_jags_nopool_procobserr <- function(
   priors = FALSE,
   
   # inheritParams runjags_bayes
+  params_out = c("GPP.daily", "ER.daily", "K600.daily", "err.obs.sigma", "err.proc.sigma", "err.proc.phi"),
   max_cores = 4, 
   adapt_steps = 100, 
   burnin_steps = 40, 
@@ -92,7 +88,6 @@ specs_bayes_jags_nopool_procobserr <- function(
   list(
     
     model_file = model_file,
-    calc_DO_fun = calc_DO_fun,
     bayes_fun = bayes_fun,
     bayes_software = bayes_software,
     
@@ -112,6 +107,7 @@ specs_bayes_jags_nopool_procobserr <- function(
     
     priors = priors,
     
+    params_out = params_out,
     max_cores = max_cores, 
     adapt_steps = adapt_steps, 
     burnin_steps = burnin_steps, 

--- a/man/runjags_bayes.Rd
+++ b/man/runjags_bayes.Rd
@@ -4,13 +4,17 @@
 \alias{runjags_bayes}
 \title{Actually run JAGS on a formatted data ply}
 \usage{
-runjags_bayes(data_list, model_path, max_cores = 4, adapt_steps = 1000,
-  burnin_steps = 4000, num_saved_steps = 40000, thin_steps = 1)
+runjags_bayes(data_list, model_path, params_out, max_cores = 4,
+  adapt_steps = 1000, burnin_steps = 4000, num_saved_steps = 40000,
+  thin_steps = 1)
 }
 \arguments{
 \item{data_list}{a formatted list of inputs to the JAGS model}
 
 \item{model_path}{the JAGS model file to use, as a full file path}
+
+\item{params_out}{a character vector of parameters whose values in the MCMC
+runs should be recorded and summarized}
 
 \item{max_cores}{the maximum number of cores to apply to this run}
 

--- a/man/specs_bayes.Rd
+++ b/man/specs_bayes.Rd
@@ -7,20 +7,22 @@
 \title{Functions giving specifications for metab_bayes model variants}
 \usage{
 specs_bayes_jags_nopool_obserr(model_file = "jags/nopool_obserr.txt",
-  calc_DO_fun = calc_DO_mod_by_diff, bayes_fun = "bayes_1ply",
-  bayes_software = "jags", GPP.daily.mu = 10, GPP.daily.sigma = 10,
-  ER.daily.mu = -10, ER.daily.sigma = 10, K600.daily.mu = 10,
-  K600.daily.sigma = 10, err.obs.sigma.min = 0, err.obs.sigma.max = 0.5,
-  priors = FALSE, max_cores = 4, adapt_steps = 100, burnin_steps = 40,
-  num_saved_steps = 400, thin_steps = 1)
+  bayes_fun = "bayes_1ply", bayes_software = "jags", GPP.daily.mu = 10,
+  GPP.daily.sigma = 10, ER.daily.mu = -10, ER.daily.sigma = 10,
+  K600.daily.mu = 10, K600.daily.sigma = 10, err.obs.sigma.min = 0,
+  err.obs.sigma.max = 0.5, priors = FALSE, params_out = c("GPP.daily",
+  "ER.daily", "K600.daily", "err.obs.sigma"), max_cores = 4,
+  adapt_steps = 100, burnin_steps = 40, num_saved_steps = 400,
+  thin_steps = 1)
 
 specs_bayes_jags_nopool_procobserr(model_file = "jags/nopool_procobserr.txt",
-  calc_DO_fun = calc_DO_mod, bayes_fun = "bayes_1ply",
-  bayes_software = "jags", GPP.daily.mu = 10, GPP.daily.sigma = 10,
-  ER.daily.mu = -10, ER.daily.sigma = 10, K600.daily.mu = 10,
-  K600.daily.sigma = 10, err.proc.phi.min = 0, err.proc.phi.max = 1,
-  err.proc.sigma.min = 0, err.proc.sigma.max = 0.005,
-  err.obs.sigma.min = 0, err.obs.sigma.max = 0.5, priors = FALSE,
+  bayes_fun = "bayes_1ply", bayes_software = "jags", GPP.daily.mu = 10,
+  GPP.daily.sigma = 10, ER.daily.mu = -10, ER.daily.sigma = 10,
+  K600.daily.mu = 10, K600.daily.sigma = 10, err.proc.phi.min = 0,
+  err.proc.phi.max = 1, err.proc.sigma.min = 0,
+  err.proc.sigma.max = 5e-04, err.obs.sigma.min = 0,
+  err.obs.sigma.max = 0.5, priors = FALSE, params_out = c("GPP.daily",
+  "ER.daily", "K600.daily", "err.obs.sigma", "err.proc.sigma", "err.proc.phi"),
   max_cores = 4, adapt_steps = 100, burnin_steps = 40,
   num_saved_steps = 400, thin_steps = 1)
 }
@@ -36,11 +38,6 @@ The containing folder (in this case \code{"jags"}) will determine which
 MCMC software package is used. The file name (in this case
 \code{"metab_bayes_simple.txt"}) will determine not only the model file to
 use but also which variables are packaged and sent to the MCMC software.}
-
-\item{calc_DO_fun}{function with which DO should be re-predicted from the
-fitted coefficients, probably either \code{calc_DO_mod} or
-\code{calc_DO_mod_by_diff}. The default value is set to match the default
-value of \code{model_file} in each \code{specs_bayes} function.}
 
 \item{bayes_fun}{character in \code{c('bayes_1ply', 'bayes_all')} indicating
 whether the data should be split into daily chunks first ('bayes_1ply') or
@@ -75,6 +72,9 @@ err.obs.sigma, the standard deviation of the observation error}
 
 \item{priors}{logical. Should the data list be modified such that JAGS will
 return priors rather than posteriors?}
+
+\item{params_out}{a character vector of parameters whose values in the MCMC
+runs should be recorded and summarized}
 
 \item{max_cores}{the maximum number of cores to apply to this run}
 


### PR DESCRIPTION
Relatively minor changes, for once. Cleans up metab_bayes a little now that I've settled on what the specs_... suite should do and how predict_DO decides to make predictions.