### PR TITLE
fitted & fixed K600_daily_sigma; bugfixes in calc_light_merged

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: streamMetabolizer
 Type: Package
 Title: Models for Estimating Aquatic Photosynthesis and Respiration
-Version: 0.9.33
-Date: 2017-01-17
+Version: 0.9.34
+Date: 2017-01-20
 Author: Alison P. Appling, Robert O. Hall, Maite Arroita, and Charles B.
     Yackulic
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
+# 0.9.34
+
+* Bayesian models with `pool_K600 != 'none'` can how have their 
+`K600_daily_sigma` (or `K600_daily_sdlog`) be a fitted value, a fixed value, or 
+a value fixed at 0
+
 # 0.9.33
 
-* new function: `calc_light_merged`, which merges modeled and observed light
+* new function: `calc_light_merged`, which merges modeled and observed light 
 into a smooth curve
 
 # 0.9.29
@@ -10,7 +16,7 @@ model (and therefore also its `info` or `data_daily` slots)
 
 # 0.9.28
 
-* switched from `rlnorm` to `rnorm` for distribution of `K600_daily` around
+* switched from `rlnorm` to `rnorm` for distribution of `K600_daily` around 
 `K600_daily_pred` in linear and binned models
 
 # 0.9.27

--- a/R/calc_light_merged.R
+++ b/R/calc_light_merged.R
@@ -23,21 +23,18 @@
 #' @export
 #' @examples 
 #' \dontrun{
-#' library(mda.streams)
 #' library(dplyr)
-#' library(lubridate)
 #' library(ggplot2)
-#' library(unitted)
-#' coords <- get_site_coords('nwis_08062500')
-#' PAR.obs <- get_ts('par_calcSw', 'nwis_08062500') %>%
-#'   mutate(solar.time = convert_UTC_to_solartime(DateTime, coords$lon)) %>%
-#'     select(solar.time, light=par) %>%
-#'     subset(solar.time %within% interval(ymd("2008-03-10"), ymd("2008-03-14"), tz=tz(solar.time)) &
-#'           !(solar.time %within% interval(as.POSIXct("2008-03-12 10:00", tz=tz(solar.time)), 
-#'                                          as.POSIXct("2008-03-12 14:00", tz=tz(solar.time)))))
-#' PAR.mod <- u(data.frame(solar.time=seq(as.POSIXct('2008-03-11', tz=tz(PAR.obs$solar.time)),
-#'     as.POSIXct('2008-03-15', tz=tz(PAR.obs$solar.time)), by=as.difftime(10, units='mins'))) %>%
-#'   mutate(light=calc_light(u(solar.time), latitude=coords$lat, longitude=coords$lon)))
+#' timebounds <- as.POSIXct(c('2008-03-12 00:00', '2008-03-12 23:59'), tz='UTC')
+#' coords <- list(lat=32.4, lon=-96.5)
+#' PAR.obs <- data_frame(
+#'   solar.time=seq(timebounds[1], timebounds[2], by=as.difftime(3, units='hours')),
+#'   light=c(0, 0, 85.9, 1160.5, 1539.0, 933.9, 0, 0)
+#' ) %>% as.data.frame()
+#' PAR.mod <- data_frame(
+#'   solar.time=seq(timebounds[1], timebounds[2], by=as.difftime(0.25, units='hours')),
+#'   light=calc_light(solar.time, latitude=coords$lat, longitude=coords$lon)
+#' ) %>% as.data.frame()
 #' PAR.merged <- calc_light_merged(PAR.obs, PAR.mod$solar.time, 
 #'   latitude=coords$lat, longitude=coords$lon, max.gap=as.difftime(20, units='hours'))
 #' ggplot(bind_rows(mutate(v(PAR.obs), type='obs'), mutate(v(PAR.mod), type='mod'), 

--- a/R/mm_name.R
+++ b/R/mm_name.R
@@ -180,7 +180,11 @@
 mm_name <- function(
   type=c('mle','bayes','night','Kmodel','sim'), 
   #pool_GPP='none', pool_ER='none', pool_eoi='alldays', pool_epc='alldays', pool_epi='alldays',
-  pool_K600=c('none','normal','linear','binned','complete'),
+  pool_K600=c('none',
+              'normal','normal_sdzero','normal_sdfixed',
+              'linear','linear_sdzero','linear_sdfixed',
+              'binned','binned_sdzero','binned_sdfixed',
+              'complete'),
   err_obs_iid=c(TRUE, FALSE),
   err_proc_acor=c(FALSE, TRUE),
   err_proc_iid=c(FALSE, TRUE),
@@ -249,7 +253,8 @@ mm_name <- function(
   # make the name
   mmname <- paste0(
     c(bayes='b', mle='m', night='n', Kmodel='K', sim='s')[[type]], '_',
-    c(none='', normal='Kn', linear='Kl', binned='Kb', complete='Kc')[[pool_K600]],
+    c(none='', normal='Kn', linear='Kl', binned='Kb', complete='Kc')[[strsplit(pool_K600, '_')[[1]][[1]]]],
+    c(none_or_fitted='', sdzero='0', sdfixed='x')[[tryCatch(strsplit(pool_K600, '_')[[1]][[2]], error=function(e) 'none_or_fitted')]],
     c(none='np', partial='', complete='')[[pool_all]], '_',
     if(err_obs_iid) 'oi', if(err_proc_acor) 'pc', if(err_proc_iid) 'pi', '_',
     c(Euler='Eu', pairmeans='pm', trapezoid='tr', rk2='r2', 

--- a/R/mm_parse_name.R
+++ b/R/mm_parse_name.R
@@ -36,7 +36,12 @@ mm_parse_name <- function(model_name, keep_name=FALSE) {
   parsed <- strsplit(basename(model_name), "_|\\.")
   sapply(1:length(parsed), function(pnum) if(length(parsed[[pnum]]) <= 5) stop('missing one or more pieces in name: ', model_name[pnum]))
   type <- unname(c(b='bayes', m='mle', n='night', K='Kmodel', s='sim')[sapply(parsed, `[`, 1)])
-  pool_K600 <- unname(c(np='none', Kn='normal', Kl='linear', Kb='binned', Kc='complete')[sapply(parsed, `[`, 2)])
+  pool_K600 <- unname(c(
+    np='none', 
+    Kn='normal', Kn0='normal_sdzero', Knx='normal_sdfixed',
+    Kl='linear', Kl0='linear_sdzero', Klx='linear_sdfixed',
+    Kb='binned', Kb0='binned_sdzero', Kbx='binned_sdfixed',
+    Kc='complete')[sapply(parsed, `[`, 2)])
   err_obs_iid <- grepl('oi', sapply(parsed, `[`, 3))
   err_proc_acor <- grepl('pc', sapply(parsed, `[`, 3))
   err_proc_iid <-  grepl('pi', sapply(parsed, `[`, 3))

--- a/R/mm_parse_name.R
+++ b/R/mm_parse_name.R
@@ -12,15 +12,17 @@
 #' @seealso The converse of this function is \code{\link{mm_name}}.
 #'   
 #' @param model_name character: the model name
-#' @param keep_name logical; should the model_name be included as a first column
-#'   in the output data.frame?
+#' @param expand logical: should additional columns such as model_name and
+#'   pool_K600_type be added? If expand=TRUE then the result cannot be passed
+#'   directly back into mm_name, but the additional columns may be helpful for 
+#'   interpreting the model structure.
 #' @import dplyr
 #' @importFrom stats na.omit
 #' @examples
 #' mm_parse_name(c(mm_name('mle'), mm_name('night'), mm_name('bayes')))
-#' mm_parse_name(c(mm_name('mle'), mm_name('night'), mm_name('bayes')), keep_name=TRUE)
+#' mm_parse_name(c(mm_name('mle'), mm_name('night'), mm_name('bayes')), expand=TRUE)
 #' @export
-mm_parse_name <- function(model_name, keep_name=FALSE) {
+mm_parse_name <- function(model_name, expand=FALSE) {
 
   # define function that gets used to parse prk_terms
   match_or_NA <- function(key, pairs) { 
@@ -42,6 +44,16 @@ mm_parse_name <- function(model_name, keep_name=FALSE) {
     Kl='linear', Kl0='linear_sdzero', Klx='linear_sdfixed',
     Kb='binned', Kb0='binned_sdzero', Kbx='binned_sdfixed',
     Kc='complete')[sapply(parsed, `[`, 2)])
+  pool_K600_type <- sapply(strsplit(pool_K600, '_'), `[[`, 1)
+  pool_K600_sd <- sapply(strsplit(pool_K600, '_'), function(pieces) {
+    if(length(pieces) >= 2) {
+      substring(pieces[[2]], 3)
+    } else if (pieces[[1]] == 'none') {
+      'fixed'
+    } else {
+      'fitted'
+    }
+  })
   err_obs_iid <- grepl('oi', sapply(parsed, `[`, 3))
   err_proc_acor <- grepl('pc', sapply(parsed, `[`, 3))
   err_proc_iid <-  grepl('pi', sapply(parsed, `[`, 3))
@@ -68,6 +80,8 @@ mm_parse_name <- function(model_name, keep_name=FALSE) {
     model_name=model_name,
     type=type,
     pool_K600=pool_K600,
+    pool_K600_type=pool_K600_type,
+    pool_K600_sd=pool_K600_sd,
     err_obs_iid=err_obs_iid,
     err_proc_acor=err_proc_acor,
     err_proc_iid=err_proc_iid,
@@ -78,7 +92,7 @@ mm_parse_name <- function(model_name, keep_name=FALSE) {
     engine=ifelse(is.na(engine), 'NA', engine), 
     stringsAsFactors=FALSE)
   
-  if(!keep_name) df$model_name <- NULL
+  if(!expand) df$model_name <- df$pool_K600_type <- df$pool_K600_sd <- NULL
   
   df
 }

--- a/R/specs.R
+++ b/R/specs.R
@@ -21,15 +21,15 @@
 #'   n_chains, n_cores, burnin_steps, saved_steps, thin_steps, verbose}. The 
 #'   need for other arguments depends on features of the model structure, as 
 #'   from \code{mm_parse_name(model_name)}: \itemize{ \item If 
-#'   \code{$pool_K600=='none'} then \code{K600_daily_meanlog, K600_daily_sdlog}.
-#'   \item If \code{$pool_K600=='normal'} then \code{K600_daily_meanlog_meanlog,
-#'   K600_daily_meanlog_sdlog, K600_daily_sdlog}. \item If 
+#'   \code{pool_K600=='none'} then \code{K600_daily_meanlog, K600_daily_sdlog}. 
+#'   \item If \code{pool_K600=='normal'} then \code{K600_daily_meanlog_meanlog, 
+#'   K600_daily_meanlog_sdlog, K600_daily_sdlog_sigma}. \item If 
 #'   \code{pool_K600=='linear'} then \code{lnK600_lnQ_intercept_mu, 
 #'   lnK600_lnQ_intercept_sigma, lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma, 
-#'   K600_daily_sigma}. \item If \code{pool_K600=='binned'} then 
+#'   K600_daily_sigma_sigma}. \item If \code{pool_K600=='binned'} then 
 #'   \code{K600_lnQ_nodes_centers, K600_lnQ_nodediffs_sdlog, 
-#'   K600_lnQ_nodes_meanlog, K600_lnQ_nodes_sdlog, K600_daily_sigma}. \item If 
-#'   \code{err_obs_iid} then \code{err_obs_iid_sigma_scale}. \item If 
+#'   K600_lnQ_nodes_meanlog, K600_lnQ_nodes_sdlog, K600_daily_sigma_sigma}. 
+#'   \item If \code{err_obs_iid} then \code{err_obs_iid_sigma_scale}. \item If 
 #'   \code{err_proc_acor} then \code{err_proc_acor_phi_alpha, 
 #'   err_proc_acor_phi_beta, err_proc_acor_sigma_scale}. \item If 
 #'   \code{err_proc_iid} then \code{ err_proc_iid_sigma_scale}.}
@@ -137,7 +137,7 @@
 #' @param GPP_daily_lower The lower bound on every fitted value of GPP_daily, 
 #'   the daily rate of gross primary production. Use values other than -Inf with
 #'   caution, recognizing that sometimes the input data are unmodelable and that
-#'   a negative estimate of GPP_daily (when unconstrained) could be your only
+#'   a negative estimate of GPP_daily (when unconstrained) could be your only 
 #'   indication.
 #' @param GPP_daily_sigma The standard deviation of a dnorm distribution for 
 #'   GPP_daily, the daily rate of gross primary production
@@ -155,12 +155,21 @@
 #' @param K600_daily_sdlog The lognormal scale parameter (standard deviation) of
 #'   a dlnorm distribution having meanlog equal to \code{K600_daily_meanlog} 
 #'   (when pool_K600 is 'none') or \code{K600_daily_predlog} (when pool_K600 is 
-#'   'normal') for K600_daily, the daily rate of reaeration as corrected for 
-#'   temperature and the diffusivity of oxygen
+#'   'normal_sdfixed') for K600_daily, the daily rate of reaeration as corrected
+#'   for temperature and the diffusivity of oxygen
 #' @param K600_daily_sigma The standard deviation of a dnorm distribution having
 #'   mean equal to \code{exp(K600_daily_predlog)} (applicable when pool_K600 is 
-#'   'linear' or 'binned') for K600_daily, the daily rate of reaeration as 
-#'   corrected for temperature and the diffusivity of oxygen
+#'   'linear_sdfixed' or 'binned_sdfixed') for K600_daily, the daily rate of 
+#'   reaeration as corrected for temperature and the diffusivity of oxygen
+#' @param K600_daily_sdlog_sigma hyperparameter for pool_K600 in c('normal'). 
+#'   The scale (= sigma) parameter of a half-normal distribution of sdlog in K ~
+#'   lN(meanlog, sdlog), sdlog ~ halfnormal(0, sigma=sdlog_sigma). Visualize the
+#'   PDF of K600_daily_sdlog with \code{\link{plot_distribs}}.
+#' @param K600_daily_sigma_sigma hyperparameter for pool_K600 in 
+#'   c('linear','binned'). The scale (= sigma) parameter of a half-normal 
+#'   distribution of sigma in K ~ lN(meanlog, sigma), sigma ~ halfnormal(0, 
+#'   sigma=sigma_sigma). Visualize the PDF of K600_daily_sdlog with 
+#'   \code{\link{plot_distribs}}.
 #'   
 #' @param K600_daily_meanlog_meanlog hyperparameter for pool_K600='normal'. The 
 #'   mean parameter (meanlog_meanlog) of a lognormal distribution of meanlog in 
@@ -352,10 +361,6 @@ specs <- function(
   K600_daily_meanlog_meanlog = log(6),
   K600_daily_meanlog_sdlog = 1,
   
-  # hyperparameters for any K pooling or non-pooling strategy
-  K600_daily_sdlog = switch(mm_parse_name(model_name)$pool_K600, none=1, normal=0.2, default=NA),
-  K600_daily_sigma = switch(mm_parse_name(model_name)$pool_K600, linear=10, binned=5, default=NA),
-  
   # hyperparameters for hierarchical K600 - linear. defaults should be
   # reasonably constrained, not too wide
   lnK600_lnQ_intercept_mu = 2,
@@ -375,6 +380,13 @@ specs <- function(
   K600_lnQ_nodediffs_sdlog = 0.05, # for centers 1 apart; for centers 0.2 apart, use 1/5 of this
   K600_lnQ_nodes_meanlog = rep(log(6), length(K600_lnQ_nodes_centers)), # distribs for the y=K600 values of the nodes
   K600_lnQ_nodes_sdlog = rep(1, length(K600_lnQ_nodes_centers)),
+  
+  # hyperparameters for any K pooling or non-pooling strategy
+  K600_daily_sdlog = switch(mm_parse_name(model_name)$pool_K600, none=1, normal_sdfixed=0.05, NA),
+  K600_daily_sigma = switch(mm_parse_name(model_name)$pool_K600, linear_sdfixed=10, binned_sdfixed=5, NA),
+  K600_daily_sdlog_sigma = switch(mm_parse_name(model_name)$pool_K600, normal=0.05, NA),
+  K600_daily_sigma_sigma = switch(mm_parse_name(model_name)$pool_K600, linear=5, binned=2, NA),
+  # normal_sdzero, linear_sdzero, and binned_sdzero all have no parameters for this
   
   # hyperparameters for error terms
   err_obs_iid_sigma_scale = 0.1,
@@ -465,7 +477,7 @@ specs <- function(
     model_name <- mm_name(type=model_name)
   
   # check the validity of the model_name against the list of officially accepted model names
-  mm_validate_name(model_name)
+ # mm_validate_name(model_name)
   
   # parse the model_name
   features <- mm_parse_name(model_name)
@@ -480,14 +492,27 @@ specs <- function(
     'bayes' = {
       
       # list the specs that will make it all the way to the Stan model as data
+      pool_K600_type <- sapply(strsplit(features$pool_K600, '_'), `[[`, 1)
+      pool_K600_sdhandling <- tryCatch({
+        sapply(strsplit(features$pool_K600, '_'), `[[`, 2)
+      }, error=function(e) {
+        if(sapply(strsplit(features$pool_K600, '_'), `[[`, 1) == 'none') 'none' else 'sdfitted'
+      })
       all_specs$params_in <- c(
         c('GPP_daily_mu','GPP_daily_lower','GPP_daily_sigma','ER_daily_mu','ER_daily_upper','ER_daily_sigma'),
         switch(
-          features$pool_K600,
+          pool_K600_type,
           none=c('K600_daily_meanlog', 'K600_daily_sdlog'),
-          normal=c('K600_daily_meanlog_meanlog', 'K600_daily_meanlog_sdlog', 'K600_daily_sdlog'),
-          linear=c('lnK600_lnQ_intercept_mu', 'lnK600_lnQ_intercept_sigma', 'lnK600_lnQ_slope_mu', 'lnK600_lnQ_slope_sigma', 'K600_daily_sigma'),
-          binned=c('K600_lnQ_nodediffs_sdlog', 'K600_lnQ_nodes_meanlog', 'K600_lnQ_nodes_sdlog', 'K600_daily_sigma')),
+          normal=c('K600_daily_meanlog_meanlog', 'K600_daily_meanlog_sdlog'),
+          linear=c('lnK600_lnQ_intercept_mu', 'lnK600_lnQ_intercept_sigma', 'lnK600_lnQ_slope_mu', 'lnK600_lnQ_slope_sigma'),
+          binned=c('K600_lnQ_nodediffs_sdlog', 'K600_lnQ_nodes_meanlog', 'K600_lnQ_nodes_sdlog')),
+        switch(
+          pool_K600_sdhandling,
+          none=c(),
+          sdzero=c(),
+          sdfixed=switch(pool_K600_type, normal='K600_daily_sdlog', linear=, binned='K600_daily_sigma'),
+          sdfitted=switch(pool_K600_type, normal='K600_daily_sdlog_sigma', linear=, binned='K600_daily_sigma_sigma')
+        ),
         if(features$err_obs_iid) 'err_obs_iid_sigma_scale',
         if(features$err_proc_acor) c('err_proc_acor_phi_alpha', 'err_proc_acor_phi_beta', 'err_proc_acor_sigma_scale'),
         if(features$err_proc_iid) 'err_proc_iid_sigma_scale'
@@ -503,7 +528,7 @@ specs <- function(
         
         # discharge binning parameters are not params_in, though they're 
         # conceptually related and therefore colocated in formals(specs)
-        if(features$pool_K600 == 'binned') c('K600_lnQ_nodes_centers'),
+        if(pool_K600_type == 'binned') c('K600_lnQ_nodes_centers'),
         
         # params_in is both a vector of specs to include and a vector to include in specs
         all_specs$params_in, 'params_in',
@@ -518,12 +543,13 @@ specs <- function(
         all_specs$engine <- features$engine
       }
       if('split_dates' %in% yes_missing) {
-        all_specs$split_dates <- ifelse(
-          features$pool_K600 %in% 'none', FALSE, # pretty sure FALSE is faster. also allows hierarchical error terms
-          ifelse(features$pool_K600 %in% c('normal','linear','binned'), FALSE, 
-                 stop("unknown pool_K600; unsure how to set split_dates")))
+        all_specs$split_dates <- switch(
+          pool_K600_type,
+          'none' = FALSE, # pretty sure FALSE is faster. also allows hierarchical error terms
+          'normal'=, 'linear'=, 'binned' = FALSE, 
+          stop("unknown pool_K600; unsure how to set split_dates"))
       }
-      if(features$pool_K600 == 'binned') {
+      if(pool_K600_type == 'binned') {
         # defaults are for linear pool_K600 & need adjustment for binned method
         all_specs$K600_daily_beta_mu <- rep(10, length(all_specs$K600_daily_lnQ_nodes))
         all_specs$K600_daily_beta_sigma <- rep(10, length(all_specs$K600_daily_lnQ_nodes))
@@ -533,11 +559,12 @@ specs <- function(
           c('GPP','ER'),
           c('GPP_daily','ER_daily','K600_daily'),
           switch(
-            features$pool_K600,
+            pool_K600_type,
             none=c(),
             normal=c('K600_daily_predlog'),
             linear=c('K600_daily_predlog', 'lnK600_lnQ_intercept', 'lnK600_lnQ_slope'),
             binned=c('K600_daily_predlog', 'lnK600_lnQ_nodes')), 
+          if(pool_K600_sdhandling == 'sdfitted') 'K600_daily_sdlog',
           if(features$err_obs_iid) c('err_obs_iid_sigma', 'err_obs_iid'),
           if(features$err_proc_acor) c('err_proc_acor', 'err_proc_acor_phi', 'err_proc_acor_sigma'),
           if(features$err_proc_iid) c('err_proc_iid_sigma', 'err_proc_iid'))

--- a/inst/models/b_Kb0_oi_eu_plrckm.stan
+++ b/inst/models/b_Kb0_oi_eu_plrckm.stan
@@ -1,0 +1,123 @@
+// b_Kb0_oi_eu_plrckm.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (binned_sdzero model)
+  int <lower=1> b; # number of K600_lnQ_nodes
+  real K600_lnQ_nodediffs_sdlog;
+  vector[b] K600_lnQ_nodes_meanlog;
+  vector[b] K600_lnQ_nodes_sdlog;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  int<lower=1,upper=b> lnQ_bins[2,d];
+  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  
+  vector[b] lnK600_lnQ_nodes;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  vector[d] K600_daily;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  
+  // Hierarchical, binned_sdzero model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_nodes[lnQ_bins[1]] .* lnQ_bin_weights[1] + 
+                       lnK600_lnQ_nodes[lnQ_bins[2]] .* lnQ_bin_weights[2];
+  K600_daily = exp(K600_daily_predlog);
+  
+  // Model DO time series
+  // * euler version
+  // * observation error
+  // * no process error
+  // * reaeration depends on DO_mod
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  DO_mod[1] = DO_obs_1;
+  for(i in 1:(n-1)) {
+    DO_mod[i+1] =
+      DO_mod[i] + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        KO2_inst[i] .* (DO_sat[i] - DO_mod[i])
+      ) * timestep;
+  }
+}
+
+model {
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  // Hierarchical constraints on K600_daily (binned_sdzero model)
+  lnK600_lnQ_nodes ~ normal(K600_lnQ_nodes_meanlog, K600_lnQ_nodes_sdlog);
+  for(k in 2:b) {
+    lnK600_lnQ_nodes[k] ~ normal(lnK600_lnQ_nodes[k-1], K600_lnQ_nodediffs_sdlog);
+  }
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kb0_oi_eu_plrcko.stan
+++ b/inst/models/b_Kb0_oi_eu_plrcko.stan
@@ -1,0 +1,123 @@
+// b_Kb0_oi_eu_plrcko.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (binned_sdzero model)
+  int <lower=1> b; # number of K600_lnQ_nodes
+  real K600_lnQ_nodediffs_sdlog;
+  vector[b] K600_lnQ_nodes_meanlog;
+  vector[b] K600_lnQ_nodes_sdlog;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  int<lower=1,upper=b> lnQ_bins[2,d];
+  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  
+  vector[b] lnK600_lnQ_nodes;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  vector[d] K600_daily;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  
+  // Hierarchical, binned_sdzero model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_nodes[lnQ_bins[1]] .* lnQ_bin_weights[1] + 
+                       lnK600_lnQ_nodes[lnQ_bins[2]] .* lnQ_bin_weights[2];
+  K600_daily = exp(K600_daily_predlog);
+  
+  // Model DO time series
+  // * euler version
+  // * observation error
+  // * no process error
+  // * reaeration depends on DO_obs
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  DO_mod[1] = DO_obs_1;
+  for(i in 1:(n-1)) {
+    DO_mod[i+1] =
+      DO_mod[i] + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        KO2_inst[i] .* (DO_sat[i] - DO_obs[i])
+      ) * timestep;
+  }
+}
+
+model {
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  // Hierarchical constraints on K600_daily (binned_sdzero model)
+  lnK600_lnQ_nodes ~ normal(K600_lnQ_nodes_meanlog, K600_lnQ_nodes_sdlog);
+  for(k in 2:b) {
+    lnK600_lnQ_nodes[k] ~ normal(lnK600_lnQ_nodes[k-1], K600_lnQ_nodediffs_sdlog);
+  }
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kb0_oi_tr_plrckm.stan
+++ b/inst/models/b_Kb0_oi_tr_plrckm.stan
@@ -1,0 +1,125 @@
+// b_Kb0_oi_tr_plrckm.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (binned_sdzero model)
+  int <lower=1> b; # number of K600_lnQ_nodes
+  real K600_lnQ_nodediffs_sdlog;
+  vector[b] K600_lnQ_nodes_meanlog;
+  vector[b] K600_lnQ_nodes_sdlog;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  int<lower=1,upper=b> lnQ_bins[2,d];
+  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  
+  vector[b] lnK600_lnQ_nodes;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  vector[d] K600_daily;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  
+  // Hierarchical, binned_sdzero model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_nodes[lnQ_bins[1]] .* lnQ_bin_weights[1] + 
+                       lnK600_lnQ_nodes[lnQ_bins[2]] .* lnQ_bin_weights[2];
+  K600_daily = exp(K600_daily_predlog);
+  
+  // Model DO time series
+  // * trapezoid version
+  // * observation error
+  // * no process error
+  // * reaeration depends on DO_mod
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  DO_mod[1] = DO_obs_1;
+  for(i in 1:(n-1)) {
+    DO_mod[i+1] =
+      DO_mod[i] .*
+        (2.0 - KO2_inst[i] * timestep) ./ (2.0 + KO2_inst[i+1] * timestep) + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        (GPP_inst[i+1] + ER_inst[i+1]) ./ depth[i+1] +
+        KO2_inst[i] .* DO_sat[i] + KO2_inst[i+1] .* DO_sat[i+1]
+      ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
+  }
+}
+
+model {
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  // Hierarchical constraints on K600_daily (binned_sdzero model)
+  lnK600_lnQ_nodes ~ normal(K600_lnQ_nodes_meanlog, K600_lnQ_nodes_sdlog);
+  for(k in 2:b) {
+    lnK600_lnQ_nodes[k] ~ normal(lnK600_lnQ_nodes[k-1], K600_lnQ_nodediffs_sdlog);
+  }
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kb0_oi_tr_plrcko.stan
+++ b/inst/models/b_Kb0_oi_tr_plrcko.stan
@@ -1,0 +1,125 @@
+// b_Kb0_oi_tr_plrcko.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (binned_sdzero model)
+  int <lower=1> b; # number of K600_lnQ_nodes
+  real K600_lnQ_nodediffs_sdlog;
+  vector[b] K600_lnQ_nodes_meanlog;
+  vector[b] K600_lnQ_nodes_sdlog;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  int<lower=1,upper=b> lnQ_bins[2,d];
+  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  
+  vector[b] lnK600_lnQ_nodes;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  vector[d] K600_daily;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  
+  // Hierarchical, binned_sdzero model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_nodes[lnQ_bins[1]] .* lnQ_bin_weights[1] + 
+                       lnK600_lnQ_nodes[lnQ_bins[2]] .* lnQ_bin_weights[2];
+  K600_daily = exp(K600_daily_predlog);
+  
+  // Model DO time series
+  // * trapezoid version
+  // * observation error
+  // * no process error
+  // * reaeration depends on DO_obs
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  DO_mod[1] = DO_obs_1;
+  for(i in 1:(n-1)) {
+    DO_mod[i+1] =
+      DO_mod[i] + (
+        - KO2_inst[i] .* DO_obs[i] - KO2_inst[i+1] .* DO_obs[i+1] +
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        (GPP_inst[i+1] + ER_inst[i+1]) ./ depth[i+1] +
+        KO2_inst[i] .* DO_sat[i] + KO2_inst[i+1] .* DO_sat[i+1]
+      ) * (timestep / 2.0);
+  }
+}
+
+model {
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  // Hierarchical constraints on K600_daily (binned_sdzero model)
+  lnK600_lnQ_nodes ~ normal(K600_lnQ_nodes_meanlog, K600_lnQ_nodes_sdlog);
+  for(k in 2:b) {
+    lnK600_lnQ_nodes[k] ~ normal(lnK600_lnQ_nodes[k-1], K600_lnQ_nodediffs_sdlog);
+  }
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kb0_oipi_eu_plrckm.stan
+++ b/inst/models/b_Kb0_oipi_eu_plrckm.stan
@@ -1,0 +1,142 @@
+// b_Kb0_oipi_eu_plrckm.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (binned_sdzero model)
+  int <lower=1> b; # number of K600_lnQ_nodes
+  real K600_lnQ_nodediffs_sdlog;
+  vector[b] K600_lnQ_nodes_meanlog;
+  vector[b] K600_lnQ_nodes_sdlog;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  int<lower=1,upper=b> lnQ_bins[2,d];
+  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  
+  vector[b] lnK600_lnQ_nodes;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+  real<lower=0> err_proc_iid_sigma_scaled;
+  vector[d] DO_mod[n];
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  vector[d] K600_daily;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, binned_sdzero model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_nodes[lnQ_bins[1]] .* lnQ_bin_weights[1] + 
+                       lnK600_lnQ_nodes[lnQ_bins[2]] .* lnQ_bin_weights[2];
+  K600_daily = exp(K600_daily_predlog);
+  
+  // Model DO time series
+  // * euler version
+  // * observation error
+  // * IID process error
+  // * reaeration depends on DO_mod
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_mod[i] + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        KO2_inst[i] .* (DO_sat[i] - DO_mod[i])
+      ) * timestep;
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        timestep ./ depth[i,j];
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_mod[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  // Hierarchical constraints on K600_daily (binned_sdzero model)
+  lnK600_lnQ_nodes ~ normal(K600_lnQ_nodes_meanlog, K600_lnQ_nodes_sdlog);
+  for(k in 2:b) {
+    lnK600_lnQ_nodes[k] ~ normal(lnK600_lnQ_nodes[k-1], K600_lnQ_nodediffs_sdlog);
+  }
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_mod[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kb0_oipi_eu_plrcko.stan
+++ b/inst/models/b_Kb0_oipi_eu_plrcko.stan
@@ -1,0 +1,142 @@
+// b_Kb0_oipi_eu_plrcko.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (binned_sdzero model)
+  int <lower=1> b; # number of K600_lnQ_nodes
+  real K600_lnQ_nodediffs_sdlog;
+  vector[b] K600_lnQ_nodes_meanlog;
+  vector[b] K600_lnQ_nodes_sdlog;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  int<lower=1,upper=b> lnQ_bins[2,d];
+  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  
+  vector[b] lnK600_lnQ_nodes;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+  real<lower=0> err_proc_iid_sigma_scaled;
+  vector[d] DO_mod[n];
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  vector[d] K600_daily;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, binned_sdzero model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_nodes[lnQ_bins[1]] .* lnQ_bin_weights[1] + 
+                       lnK600_lnQ_nodes[lnQ_bins[2]] .* lnQ_bin_weights[2];
+  K600_daily = exp(K600_daily_predlog);
+  
+  // Model DO time series
+  // * euler version
+  // * observation error
+  // * IID process error
+  // * reaeration depends on DO_obs
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_mod[i] + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        KO2_inst[i] .* (DO_sat[i] - DO_obs[i])
+      ) * timestep;
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        timestep ./ depth[i,j];
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_mod[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  // Hierarchical constraints on K600_daily (binned_sdzero model)
+  lnK600_lnQ_nodes ~ normal(K600_lnQ_nodes_meanlog, K600_lnQ_nodes_sdlog);
+  for(k in 2:b) {
+    lnK600_lnQ_nodes[k] ~ normal(lnK600_lnQ_nodes[k-1], K600_lnQ_nodediffs_sdlog);
+  }
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_mod[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kb0_oipi_tr_plrckm.stan
+++ b/inst/models/b_Kb0_oipi_tr_plrckm.stan
@@ -1,0 +1,145 @@
+// b_Kb0_oipi_tr_plrckm.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (binned_sdzero model)
+  int <lower=1> b; # number of K600_lnQ_nodes
+  real K600_lnQ_nodediffs_sdlog;
+  vector[b] K600_lnQ_nodes_meanlog;
+  vector[b] K600_lnQ_nodes_sdlog;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  int<lower=1,upper=b> lnQ_bins[2,d];
+  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  
+  vector[b] lnK600_lnQ_nodes;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+  real<lower=0> err_proc_iid_sigma_scaled;
+  vector[d] DO_mod[n];
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  vector[d] K600_daily;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, binned_sdzero model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_nodes[lnQ_bins[1]] .* lnQ_bin_weights[1] + 
+                       lnK600_lnQ_nodes[lnQ_bins[2]] .* lnQ_bin_weights[2];
+  K600_daily = exp(K600_daily_predlog);
+  
+  // Model DO time series
+  // * trapezoid version
+  // * observation error
+  // * IID process error
+  // * reaeration depends on DO_mod
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_mod[i] .*
+        (2.0 - KO2_inst[i] * timestep) ./ (2.0 + KO2_inst[i+1] * timestep) + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        (GPP_inst[i+1] + ER_inst[i+1]) ./ depth[i+1] +
+        KO2_inst[i] .* DO_sat[i] + KO2_inst[i+1] .* DO_sat[i+1]
+      ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_mod[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  // Hierarchical constraints on K600_daily (binned_sdzero model)
+  lnK600_lnQ_nodes ~ normal(K600_lnQ_nodes_meanlog, K600_lnQ_nodes_sdlog);
+  for(k in 2:b) {
+    lnK600_lnQ_nodes[k] ~ normal(lnK600_lnQ_nodes[k-1], K600_lnQ_nodediffs_sdlog);
+  }
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_mod[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kb0_oipi_tr_plrcko.stan
+++ b/inst/models/b_Kb0_oipi_tr_plrcko.stan
@@ -1,0 +1,145 @@
+// b_Kb0_oipi_tr_plrcko.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (binned_sdzero model)
+  int <lower=1> b; # number of K600_lnQ_nodes
+  real K600_lnQ_nodediffs_sdlog;
+  vector[b] K600_lnQ_nodes_meanlog;
+  vector[b] K600_lnQ_nodes_sdlog;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  int<lower=1,upper=b> lnQ_bins[2,d];
+  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  
+  vector[b] lnK600_lnQ_nodes;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+  real<lower=0> err_proc_iid_sigma_scaled;
+  vector[d] DO_mod[n];
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  vector[d] K600_daily;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, binned_sdzero model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_nodes[lnQ_bins[1]] .* lnQ_bin_weights[1] + 
+                       lnK600_lnQ_nodes[lnQ_bins[2]] .* lnQ_bin_weights[2];
+  K600_daily = exp(K600_daily_predlog);
+  
+  // Model DO time series
+  // * trapezoid version
+  // * observation error
+  // * IID process error
+  // * reaeration depends on DO_obs
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_mod[i] + (
+        - KO2_inst[i] .* DO_obs[i] - KO2_inst[i+1] .* DO_obs[i+1] +
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        (GPP_inst[i+1] + ER_inst[i+1]) ./ depth[i+1] +
+        KO2_inst[i] .* DO_sat[i] + KO2_inst[i+1] .* DO_sat[i+1]
+      ) * (timestep / 2.0);
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        (timestep / 2.0);
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_mod[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  // Hierarchical constraints on K600_daily (binned_sdzero model)
+  lnK600_lnQ_nodes ~ normal(K600_lnQ_nodes_meanlog, K600_lnQ_nodes_sdlog);
+  for(k in 2:b) {
+    lnK600_lnQ_nodes[k] ~ normal(lnK600_lnQ_nodes[k-1], K600_lnQ_nodediffs_sdlog);
+  }
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_mod[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kb0_pi_eu_plrckm.stan
+++ b/inst/models/b_Kb0_pi_eu_plrckm.stan
@@ -1,0 +1,130 @@
+// b_Kb0_pi_eu_plrckm.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (binned_sdzero model)
+  int <lower=1> b; # number of K600_lnQ_nodes
+  real K600_lnQ_nodediffs_sdlog;
+  vector[b] K600_lnQ_nodes_meanlog;
+  vector[b] K600_lnQ_nodes_sdlog;
+  
+  // Error distributions
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  int<lower=1,upper=b> lnQ_bins[2,d];
+  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  
+  vector[b] lnK600_lnQ_nodes;
+  
+  real<lower=0> err_proc_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  vector[d] K600_daily;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, binned_sdzero model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_nodes[lnQ_bins[1]] .* lnQ_bin_weights[1] + 
+                       lnK600_lnQ_nodes[lnQ_bins[2]] .* lnQ_bin_weights[2];
+  K600_daily = exp(K600_daily_predlog);
+  
+  // Model DO time series
+  // * euler version
+  // * no observation error
+  // * IID process error
+  // * reaeration depends on DO_mod
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  DO_mod_partial[1] = DO_obs_1;
+  DO_mod_partial_sigma[1] = err_proc_iid_sigma * timestep ./ depth[1];
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_obs[i] + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        KO2_inst[i] .* (DO_sat[i] - DO_mod_partial[i])
+      ) * timestep;
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        timestep ./ depth[i,j];
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_obs[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  // Hierarchical constraints on K600_daily (binned_sdzero model)
+  lnK600_lnQ_nodes ~ normal(K600_lnQ_nodes_meanlog, K600_lnQ_nodes_sdlog);
+  for(k in 2:b) {
+    lnK600_lnQ_nodes[k] ~ normal(lnK600_lnQ_nodes[k-1], K600_lnQ_nodediffs_sdlog);
+  }
+  
+}
+generated quantities {
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_obs[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kb0_pi_eu_plrcko.stan
+++ b/inst/models/b_Kb0_pi_eu_plrcko.stan
@@ -1,0 +1,128 @@
+// b_Kb0_pi_eu_plrcko.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (binned_sdzero model)
+  int <lower=1> b; # number of K600_lnQ_nodes
+  real K600_lnQ_nodediffs_sdlog;
+  vector[b] K600_lnQ_nodes_meanlog;
+  vector[b] K600_lnQ_nodes_sdlog;
+  
+  // Error distributions
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  int<lower=1,upper=b> lnQ_bins[2,d];
+  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  
+  vector[b] lnK600_lnQ_nodes;
+  
+  real<lower=0> err_proc_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  vector[d] K600_daily;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, binned_sdzero model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_nodes[lnQ_bins[1]] .* lnQ_bin_weights[1] + 
+                       lnK600_lnQ_nodes[lnQ_bins[2]] .* lnQ_bin_weights[2];
+  K600_daily = exp(K600_daily_predlog);
+  
+  // Model DO time series
+  // * euler version
+  // * no observation error
+  // * IID process error
+  // * reaeration depends on DO_obs
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_obs[i] + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        KO2_inst[i] .* (DO_sat[i] - DO_obs[i])
+      ) * timestep;
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        timestep ./ depth[i,j];
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_obs[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  // Hierarchical constraints on K600_daily (binned_sdzero model)
+  lnK600_lnQ_nodes ~ normal(K600_lnQ_nodes_meanlog, K600_lnQ_nodes_sdlog);
+  for(k in 2:b) {
+    lnK600_lnQ_nodes[k] ~ normal(lnK600_lnQ_nodes[k-1], K600_lnQ_nodediffs_sdlog);
+  }
+  
+}
+generated quantities {
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_obs[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kb0_pi_tr_plrckm.stan
+++ b/inst/models/b_Kb0_pi_tr_plrckm.stan
@@ -1,0 +1,133 @@
+// b_Kb0_pi_tr_plrckm.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (binned_sdzero model)
+  int <lower=1> b; # number of K600_lnQ_nodes
+  real K600_lnQ_nodediffs_sdlog;
+  vector[b] K600_lnQ_nodes_meanlog;
+  vector[b] K600_lnQ_nodes_sdlog;
+  
+  // Error distributions
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  int<lower=1,upper=b> lnQ_bins[2,d];
+  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  
+  vector[b] lnK600_lnQ_nodes;
+  
+  real<lower=0> err_proc_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  vector[d] K600_daily;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, binned_sdzero model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_nodes[lnQ_bins[1]] .* lnQ_bin_weights[1] + 
+                       lnK600_lnQ_nodes[lnQ_bins[2]] .* lnQ_bin_weights[2];
+  K600_daily = exp(K600_daily_predlog);
+  
+  // Model DO time series
+  // * trapezoid version
+  // * no observation error
+  // * IID process error
+  // * reaeration depends on DO_mod
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  DO_mod_partial[1] = DO_obs_1;
+  DO_mod_partial_sigma[1] = err_proc_iid_sigma * timestep ./ depth[1];
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_mod_partial[i] .*
+        (2.0 - KO2_inst[i] * timestep) ./ (2.0 + KO2_inst[i+1] * timestep) + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        (GPP_inst[i+1] + ER_inst[i+1]) ./ depth[i+1] +
+        KO2_inst[i] .* DO_sat[i] + KO2_inst[i+1] .* DO_sat[i+1]
+      ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_obs[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  // Hierarchical constraints on K600_daily (binned_sdzero model)
+  lnK600_lnQ_nodes ~ normal(K600_lnQ_nodes_meanlog, K600_lnQ_nodes_sdlog);
+  for(k in 2:b) {
+    lnK600_lnQ_nodes[k] ~ normal(lnK600_lnQ_nodes[k-1], K600_lnQ_nodediffs_sdlog);
+  }
+  
+}
+generated quantities {
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_obs[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kb0_pi_tr_plrcko.stan
+++ b/inst/models/b_Kb0_pi_tr_plrcko.stan
@@ -1,0 +1,131 @@
+// b_Kb0_pi_tr_plrcko.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (binned_sdzero model)
+  int <lower=1> b; # number of K600_lnQ_nodes
+  real K600_lnQ_nodediffs_sdlog;
+  vector[b] K600_lnQ_nodes_meanlog;
+  vector[b] K600_lnQ_nodes_sdlog;
+  
+  // Error distributions
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  int<lower=1,upper=b> lnQ_bins[2,d];
+  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  
+  vector[b] lnK600_lnQ_nodes;
+  
+  real<lower=0> err_proc_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  vector[d] K600_daily;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, binned_sdzero model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_nodes[lnQ_bins[1]] .* lnQ_bin_weights[1] + 
+                       lnK600_lnQ_nodes[lnQ_bins[2]] .* lnQ_bin_weights[2];
+  K600_daily = exp(K600_daily_predlog);
+  
+  // Model DO time series
+  // * trapezoid version
+  // * no observation error
+  // * IID process error
+  // * reaeration depends on DO_obs
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_obs[i] + (
+        - KO2_inst[i] .* DO_obs[i] - KO2_inst[i+1] .* DO_obs[i+1] +
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        (GPP_inst[i+1] + ER_inst[i+1]) ./ depth[i+1] +
+        KO2_inst[i] .* DO_sat[i] + KO2_inst[i+1] .* DO_sat[i+1]
+      ) * (timestep / 2.0);
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        (timestep / 2.0);
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_obs[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  // Hierarchical constraints on K600_daily (binned_sdzero model)
+  lnK600_lnQ_nodes ~ normal(K600_lnQ_nodes_meanlog, K600_lnQ_nodes_sdlog);
+  for(k in 2:b) {
+    lnK600_lnQ_nodes[k] ~ normal(lnK600_lnQ_nodes[k-1], K600_lnQ_nodediffs_sdlog);
+  }
+  
+}
+generated quantities {
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_obs[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kb_oi_eu_plrckm.stan
+++ b/inst/models/b_Kb_oi_eu_plrckm.stan
@@ -14,7 +14,7 @@ data {
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
-  real<lower=0> K600_daily_sigma;
+  real<lower=0> K600_daily_sigma_sigma;
   
   // Error distributions
   real<lower=0> err_obs_iid_sigma_scale;
@@ -46,17 +46,22 @@ parameters {
   vector<lower=0>[d] K600_daily;
   
   vector[b] lnK600_lnQ_nodes;
+  real<lower=0> K600_daily_sigma_scaled;
   
   real<lower=0> err_obs_iid_sigma_scaled;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
+  real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
   vector[d] GPP_inst[n];
   vector[d] ER_inst[n];
   vector[d] KO2_inst[n];
   vector[d] DO_mod[n];
+  
+  // Rescale pooling distribution parameter
+  K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -106,6 +111,7 @@ model {
   for(k in 2:b) {
     lnK600_lnQ_nodes[k] ~ normal(lnK600_lnQ_nodes[k-1], K600_lnQ_nodediffs_sdlog);
   }
+  K600_daily_sigma_scaled ~ normal(0, 1);
   
 }
 generated quantities {

--- a/inst/models/b_Kb_oi_eu_plrcko.stan
+++ b/inst/models/b_Kb_oi_eu_plrcko.stan
@@ -14,7 +14,7 @@ data {
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
-  real<lower=0> K600_daily_sigma;
+  real<lower=0> K600_daily_sigma_sigma;
   
   // Error distributions
   real<lower=0> err_obs_iid_sigma_scale;
@@ -46,17 +46,22 @@ parameters {
   vector<lower=0>[d] K600_daily;
   
   vector[b] lnK600_lnQ_nodes;
+  real<lower=0> K600_daily_sigma_scaled;
   
   real<lower=0> err_obs_iid_sigma_scaled;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
+  real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
   vector[d] GPP_inst[n];
   vector[d] ER_inst[n];
   vector[d] KO2_inst[n];
   vector[d] DO_mod[n];
+  
+  // Rescale pooling distribution parameter
+  K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -106,6 +111,7 @@ model {
   for(k in 2:b) {
     lnK600_lnQ_nodes[k] ~ normal(lnK600_lnQ_nodes[k-1], K600_lnQ_nodediffs_sdlog);
   }
+  K600_daily_sigma_scaled ~ normal(0, 1);
   
 }
 generated quantities {

--- a/inst/models/b_Kb_oi_tr_plrckm.stan
+++ b/inst/models/b_Kb_oi_tr_plrckm.stan
@@ -14,7 +14,7 @@ data {
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
-  real<lower=0> K600_daily_sigma;
+  real<lower=0> K600_daily_sigma_sigma;
   
   // Error distributions
   real<lower=0> err_obs_iid_sigma_scale;
@@ -46,17 +46,22 @@ parameters {
   vector<lower=0>[d] K600_daily;
   
   vector[b] lnK600_lnQ_nodes;
+  real<lower=0> K600_daily_sigma_scaled;
   
   real<lower=0> err_obs_iid_sigma_scaled;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
+  real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
   vector[d] GPP_inst[n];
   vector[d] ER_inst[n];
   vector[d] KO2_inst[n];
   vector[d] DO_mod[n];
+  
+  // Rescale pooling distribution parameter
+  K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -108,6 +113,7 @@ model {
   for(k in 2:b) {
     lnK600_lnQ_nodes[k] ~ normal(lnK600_lnQ_nodes[k-1], K600_lnQ_nodediffs_sdlog);
   }
+  K600_daily_sigma_scaled ~ normal(0, 1);
   
 }
 generated quantities {

--- a/inst/models/b_Kb_oi_tr_plrcko.stan
+++ b/inst/models/b_Kb_oi_tr_plrcko.stan
@@ -14,7 +14,7 @@ data {
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
-  real<lower=0> K600_daily_sigma;
+  real<lower=0> K600_daily_sigma_sigma;
   
   // Error distributions
   real<lower=0> err_obs_iid_sigma_scale;
@@ -46,17 +46,22 @@ parameters {
   vector<lower=0>[d] K600_daily;
   
   vector[b] lnK600_lnQ_nodes;
+  real<lower=0> K600_daily_sigma_scaled;
   
   real<lower=0> err_obs_iid_sigma_scaled;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
+  real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
   vector[d] GPP_inst[n];
   vector[d] ER_inst[n];
   vector[d] KO2_inst[n];
   vector[d] DO_mod[n];
+  
+  // Rescale pooling distribution parameter
+  K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -108,6 +113,7 @@ model {
   for(k in 2:b) {
     lnK600_lnQ_nodes[k] ~ normal(lnK600_lnQ_nodes[k-1], K600_lnQ_nodediffs_sdlog);
   }
+  K600_daily_sigma_scaled ~ normal(0, 1);
   
 }
 generated quantities {

--- a/inst/models/b_Kb_oipi_eu_plrckm.stan
+++ b/inst/models/b_Kb_oipi_eu_plrckm.stan
@@ -14,7 +14,7 @@ data {
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
-  real<lower=0> K600_daily_sigma;
+  real<lower=0> K600_daily_sigma_sigma;
   
   // Error distributions
   real<lower=0> err_obs_iid_sigma_scale;
@@ -47,6 +47,7 @@ parameters {
   vector<lower=0>[d] K600_daily;
   
   vector[b] lnK600_lnQ_nodes;
+  real<lower=0> K600_daily_sigma_scaled;
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
@@ -55,6 +56,7 @@ parameters {
 
 transformed parameters {
   vector[d] K600_daily_predlog;
+  real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
   vector[d] DO_mod_partial_sigma[n];
   real<lower=0> err_proc_iid_sigma;
@@ -62,6 +64,9 @@ transformed parameters {
   vector[d] ER_inst[n];
   vector[d] KO2_inst[n];
   vector[d] DO_mod_partial[n];
+  
+  // Rescale pooling distribution parameter
+  K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -123,6 +128,7 @@ model {
   for(k in 2:b) {
     lnK600_lnQ_nodes[k] ~ normal(lnK600_lnQ_nodes[k-1], K600_lnQ_nodediffs_sdlog);
   }
+  K600_daily_sigma_scaled ~ normal(0, 1);
   
 }
 generated quantities {

--- a/inst/models/b_Kb_oipi_eu_plrcko.stan
+++ b/inst/models/b_Kb_oipi_eu_plrcko.stan
@@ -14,7 +14,7 @@ data {
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
-  real<lower=0> K600_daily_sigma;
+  real<lower=0> K600_daily_sigma_sigma;
   
   // Error distributions
   real<lower=0> err_obs_iid_sigma_scale;
@@ -47,6 +47,7 @@ parameters {
   vector<lower=0>[d] K600_daily;
   
   vector[b] lnK600_lnQ_nodes;
+  real<lower=0> K600_daily_sigma_scaled;
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
@@ -55,6 +56,7 @@ parameters {
 
 transformed parameters {
   vector[d] K600_daily_predlog;
+  real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
   vector[d] DO_mod_partial_sigma[n];
   real<lower=0> err_proc_iid_sigma;
@@ -62,6 +64,9 @@ transformed parameters {
   vector[d] ER_inst[n];
   vector[d] KO2_inst[n];
   vector[d] DO_mod_partial[n];
+  
+  // Rescale pooling distribution parameter
+  K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -123,6 +128,7 @@ model {
   for(k in 2:b) {
     lnK600_lnQ_nodes[k] ~ normal(lnK600_lnQ_nodes[k-1], K600_lnQ_nodediffs_sdlog);
   }
+  K600_daily_sigma_scaled ~ normal(0, 1);
   
 }
 generated quantities {

--- a/inst/models/b_Kb_oipi_tr_plrckm.stan
+++ b/inst/models/b_Kb_oipi_tr_plrckm.stan
@@ -14,7 +14,7 @@ data {
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
-  real<lower=0> K600_daily_sigma;
+  real<lower=0> K600_daily_sigma_sigma;
   
   // Error distributions
   real<lower=0> err_obs_iid_sigma_scale;
@@ -47,6 +47,7 @@ parameters {
   vector<lower=0>[d] K600_daily;
   
   vector[b] lnK600_lnQ_nodes;
+  real<lower=0> K600_daily_sigma_scaled;
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
@@ -55,6 +56,7 @@ parameters {
 
 transformed parameters {
   vector[d] K600_daily_predlog;
+  real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
   vector[d] DO_mod_partial_sigma[n];
   real<lower=0> err_proc_iid_sigma;
@@ -62,6 +64,9 @@ transformed parameters {
   vector[d] ER_inst[n];
   vector[d] KO2_inst[n];
   vector[d] DO_mod_partial[n];
+  
+  // Rescale pooling distribution parameter
+  K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -126,6 +131,7 @@ model {
   for(k in 2:b) {
     lnK600_lnQ_nodes[k] ~ normal(lnK600_lnQ_nodes[k-1], K600_lnQ_nodediffs_sdlog);
   }
+  K600_daily_sigma_scaled ~ normal(0, 1);
   
 }
 generated quantities {

--- a/inst/models/b_Kb_oipi_tr_plrcko.stan
+++ b/inst/models/b_Kb_oipi_tr_plrcko.stan
@@ -14,7 +14,7 @@ data {
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
-  real<lower=0> K600_daily_sigma;
+  real<lower=0> K600_daily_sigma_sigma;
   
   // Error distributions
   real<lower=0> err_obs_iid_sigma_scale;
@@ -47,6 +47,7 @@ parameters {
   vector<lower=0>[d] K600_daily;
   
   vector[b] lnK600_lnQ_nodes;
+  real<lower=0> K600_daily_sigma_scaled;
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
@@ -55,6 +56,7 @@ parameters {
 
 transformed parameters {
   vector[d] K600_daily_predlog;
+  real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
   vector[d] DO_mod_partial_sigma[n];
   real<lower=0> err_proc_iid_sigma;
@@ -62,6 +64,9 @@ transformed parameters {
   vector[d] ER_inst[n];
   vector[d] KO2_inst[n];
   vector[d] DO_mod_partial[n];
+  
+  // Rescale pooling distribution parameter
+  K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -126,6 +131,7 @@ model {
   for(k in 2:b) {
     lnK600_lnQ_nodes[k] ~ normal(lnK600_lnQ_nodes[k-1], K600_lnQ_nodediffs_sdlog);
   }
+  K600_daily_sigma_scaled ~ normal(0, 1);
   
 }
 generated quantities {

--- a/inst/models/b_Kb_pi_eu_plrckm.stan
+++ b/inst/models/b_Kb_pi_eu_plrckm.stan
@@ -14,7 +14,7 @@ data {
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
-  real<lower=0> K600_daily_sigma;
+  real<lower=0> K600_daily_sigma_sigma;
   
   // Error distributions
   real<lower=0> err_proc_iid_sigma_scale;
@@ -46,18 +46,23 @@ parameters {
   vector<lower=0>[d] K600_daily;
   
   vector[b] lnK600_lnQ_nodes;
+  real<lower=0> K600_daily_sigma_scaled;
   
   real<lower=0> err_proc_iid_sigma_scaled;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
+  real<lower=0> K600_daily_sigma;
   vector[d] DO_mod_partial_sigma[n];
   real<lower=0> err_proc_iid_sigma;
   vector[d] GPP_inst[n];
   vector[d] ER_inst[n];
   vector[d] KO2_inst[n];
   vector[d] DO_mod_partial[n];
+  
+  // Rescale pooling distribution parameter
+  K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -113,6 +118,7 @@ model {
   for(k in 2:b) {
     lnK600_lnQ_nodes[k] ~ normal(lnK600_lnQ_nodes[k-1], K600_lnQ_nodediffs_sdlog);
   }
+  K600_daily_sigma_scaled ~ normal(0, 1);
   
 }
 generated quantities {

--- a/inst/models/b_Kb_pi_eu_plrcko.stan
+++ b/inst/models/b_Kb_pi_eu_plrcko.stan
@@ -14,7 +14,7 @@ data {
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
-  real<lower=0> K600_daily_sigma;
+  real<lower=0> K600_daily_sigma_sigma;
   
   // Error distributions
   real<lower=0> err_proc_iid_sigma_scale;
@@ -46,18 +46,23 @@ parameters {
   vector<lower=0>[d] K600_daily;
   
   vector[b] lnK600_lnQ_nodes;
+  real<lower=0> K600_daily_sigma_scaled;
   
   real<lower=0> err_proc_iid_sigma_scaled;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
+  real<lower=0> K600_daily_sigma;
   vector[d] DO_mod_partial_sigma[n];
   real<lower=0> err_proc_iid_sigma;
   vector[d] GPP_inst[n];
   vector[d] ER_inst[n];
   vector[d] KO2_inst[n];
   vector[d] DO_mod_partial[n];
+  
+  // Rescale pooling distribution parameter
+  K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -111,6 +116,7 @@ model {
   for(k in 2:b) {
     lnK600_lnQ_nodes[k] ~ normal(lnK600_lnQ_nodes[k-1], K600_lnQ_nodediffs_sdlog);
   }
+  K600_daily_sigma_scaled ~ normal(0, 1);
   
 }
 generated quantities {

--- a/inst/models/b_Kb_pi_tr_plrckm.stan
+++ b/inst/models/b_Kb_pi_tr_plrckm.stan
@@ -14,7 +14,7 @@ data {
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
-  real<lower=0> K600_daily_sigma;
+  real<lower=0> K600_daily_sigma_sigma;
   
   // Error distributions
   real<lower=0> err_proc_iid_sigma_scale;
@@ -46,18 +46,23 @@ parameters {
   vector<lower=0>[d] K600_daily;
   
   vector[b] lnK600_lnQ_nodes;
+  real<lower=0> K600_daily_sigma_scaled;
   
   real<lower=0> err_proc_iid_sigma_scaled;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
+  real<lower=0> K600_daily_sigma;
   vector[d] DO_mod_partial_sigma[n];
   real<lower=0> err_proc_iid_sigma;
   vector[d] GPP_inst[n];
   vector[d] ER_inst[n];
   vector[d] KO2_inst[n];
   vector[d] DO_mod_partial[n];
+  
+  // Rescale pooling distribution parameter
+  K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -116,6 +121,7 @@ model {
   for(k in 2:b) {
     lnK600_lnQ_nodes[k] ~ normal(lnK600_lnQ_nodes[k-1], K600_lnQ_nodediffs_sdlog);
   }
+  K600_daily_sigma_scaled ~ normal(0, 1);
   
 }
 generated quantities {

--- a/inst/models/b_Kb_pi_tr_plrcko.stan
+++ b/inst/models/b_Kb_pi_tr_plrcko.stan
@@ -14,7 +14,7 @@ data {
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
-  real<lower=0> K600_daily_sigma;
+  real<lower=0> K600_daily_sigma_sigma;
   
   // Error distributions
   real<lower=0> err_proc_iid_sigma_scale;
@@ -46,18 +46,23 @@ parameters {
   vector<lower=0>[d] K600_daily;
   
   vector[b] lnK600_lnQ_nodes;
+  real<lower=0> K600_daily_sigma_scaled;
   
   real<lower=0> err_proc_iid_sigma_scaled;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
+  real<lower=0> K600_daily_sigma;
   vector[d] DO_mod_partial_sigma[n];
   real<lower=0> err_proc_iid_sigma;
   vector[d] GPP_inst[n];
   vector[d] ER_inst[n];
   vector[d] KO2_inst[n];
   vector[d] DO_mod_partial[n];
+  
+  // Rescale pooling distribution parameter
+  K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -114,6 +119,7 @@ model {
   for(k in 2:b) {
     lnK600_lnQ_nodes[k] ~ normal(lnK600_lnQ_nodes[k-1], K600_lnQ_nodediffs_sdlog);
   }
+  K600_daily_sigma_scaled ~ normal(0, 1);
   
 }
 generated quantities {

--- a/inst/models/b_Kbx_oi_eu_plrckm.stan
+++ b/inst/models/b_Kbx_oi_eu_plrckm.stan
@@ -1,0 +1,124 @@
+// b_Kbx_oi_eu_plrckm.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (binned_sdfixed model)
+  int <lower=1> b; # number of K600_lnQ_nodes
+  real K600_lnQ_nodediffs_sdlog;
+  vector[b] K600_lnQ_nodes_meanlog;
+  vector[b] K600_lnQ_nodes_sdlog;
+  real<lower=0> K600_daily_sigma;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  int<lower=1,upper=b> lnQ_bins[2,d];
+  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  vector<lower=0>[d] K600_daily;
+  
+  vector[b] lnK600_lnQ_nodes;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  
+  // Hierarchical, binned_sdfixed model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_nodes[lnQ_bins[1]] .* lnQ_bin_weights[1] + 
+                       lnK600_lnQ_nodes[lnQ_bins[2]] .* lnQ_bin_weights[2];
+  
+  // Model DO time series
+  // * euler version
+  // * observation error
+  // * no process error
+  // * reaeration depends on DO_mod
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  DO_mod[1] = DO_obs_1;
+  for(i in 1:(n-1)) {
+    DO_mod[i+1] =
+      DO_mod[i] + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        KO2_inst[i] .* (DO_sat[i] - DO_mod[i])
+      ) * timestep;
+  }
+}
+
+model {
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  K600_daily ~ normal(exp(K600_daily_predlog), K600_daily_sigma);
+  // Hierarchical constraints on K600_daily (binned_sdfixed model)
+  lnK600_lnQ_nodes ~ normal(K600_lnQ_nodes_meanlog, K600_lnQ_nodes_sdlog);
+  for(k in 2:b) {
+    lnK600_lnQ_nodes[k] ~ normal(lnK600_lnQ_nodes[k-1], K600_lnQ_nodediffs_sdlog);
+  }
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kbx_oi_eu_plrcko.stan
+++ b/inst/models/b_Kbx_oi_eu_plrcko.stan
@@ -1,0 +1,124 @@
+// b_Kbx_oi_eu_plrcko.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (binned_sdfixed model)
+  int <lower=1> b; # number of K600_lnQ_nodes
+  real K600_lnQ_nodediffs_sdlog;
+  vector[b] K600_lnQ_nodes_meanlog;
+  vector[b] K600_lnQ_nodes_sdlog;
+  real<lower=0> K600_daily_sigma;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  int<lower=1,upper=b> lnQ_bins[2,d];
+  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  vector<lower=0>[d] K600_daily;
+  
+  vector[b] lnK600_lnQ_nodes;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  
+  // Hierarchical, binned_sdfixed model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_nodes[lnQ_bins[1]] .* lnQ_bin_weights[1] + 
+                       lnK600_lnQ_nodes[lnQ_bins[2]] .* lnQ_bin_weights[2];
+  
+  // Model DO time series
+  // * euler version
+  // * observation error
+  // * no process error
+  // * reaeration depends on DO_obs
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  DO_mod[1] = DO_obs_1;
+  for(i in 1:(n-1)) {
+    DO_mod[i+1] =
+      DO_mod[i] + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        KO2_inst[i] .* (DO_sat[i] - DO_obs[i])
+      ) * timestep;
+  }
+}
+
+model {
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  K600_daily ~ normal(exp(K600_daily_predlog), K600_daily_sigma);
+  // Hierarchical constraints on K600_daily (binned_sdfixed model)
+  lnK600_lnQ_nodes ~ normal(K600_lnQ_nodes_meanlog, K600_lnQ_nodes_sdlog);
+  for(k in 2:b) {
+    lnK600_lnQ_nodes[k] ~ normal(lnK600_lnQ_nodes[k-1], K600_lnQ_nodediffs_sdlog);
+  }
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kbx_oi_tr_plrckm.stan
+++ b/inst/models/b_Kbx_oi_tr_plrckm.stan
@@ -1,0 +1,126 @@
+// b_Kbx_oi_tr_plrckm.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (binned_sdfixed model)
+  int <lower=1> b; # number of K600_lnQ_nodes
+  real K600_lnQ_nodediffs_sdlog;
+  vector[b] K600_lnQ_nodes_meanlog;
+  vector[b] K600_lnQ_nodes_sdlog;
+  real<lower=0> K600_daily_sigma;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  int<lower=1,upper=b> lnQ_bins[2,d];
+  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  vector<lower=0>[d] K600_daily;
+  
+  vector[b] lnK600_lnQ_nodes;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  
+  // Hierarchical, binned_sdfixed model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_nodes[lnQ_bins[1]] .* lnQ_bin_weights[1] + 
+                       lnK600_lnQ_nodes[lnQ_bins[2]] .* lnQ_bin_weights[2];
+  
+  // Model DO time series
+  // * trapezoid version
+  // * observation error
+  // * no process error
+  // * reaeration depends on DO_mod
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  DO_mod[1] = DO_obs_1;
+  for(i in 1:(n-1)) {
+    DO_mod[i+1] =
+      DO_mod[i] .*
+        (2.0 - KO2_inst[i] * timestep) ./ (2.0 + KO2_inst[i+1] * timestep) + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        (GPP_inst[i+1] + ER_inst[i+1]) ./ depth[i+1] +
+        KO2_inst[i] .* DO_sat[i] + KO2_inst[i+1] .* DO_sat[i+1]
+      ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
+  }
+}
+
+model {
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  K600_daily ~ normal(exp(K600_daily_predlog), K600_daily_sigma);
+  // Hierarchical constraints on K600_daily (binned_sdfixed model)
+  lnK600_lnQ_nodes ~ normal(K600_lnQ_nodes_meanlog, K600_lnQ_nodes_sdlog);
+  for(k in 2:b) {
+    lnK600_lnQ_nodes[k] ~ normal(lnK600_lnQ_nodes[k-1], K600_lnQ_nodediffs_sdlog);
+  }
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kbx_oi_tr_plrcko.stan
+++ b/inst/models/b_Kbx_oi_tr_plrcko.stan
@@ -1,0 +1,126 @@
+// b_Kbx_oi_tr_plrcko.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (binned_sdfixed model)
+  int <lower=1> b; # number of K600_lnQ_nodes
+  real K600_lnQ_nodediffs_sdlog;
+  vector[b] K600_lnQ_nodes_meanlog;
+  vector[b] K600_lnQ_nodes_sdlog;
+  real<lower=0> K600_daily_sigma;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  int<lower=1,upper=b> lnQ_bins[2,d];
+  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  vector<lower=0>[d] K600_daily;
+  
+  vector[b] lnK600_lnQ_nodes;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  
+  // Hierarchical, binned_sdfixed model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_nodes[lnQ_bins[1]] .* lnQ_bin_weights[1] + 
+                       lnK600_lnQ_nodes[lnQ_bins[2]] .* lnQ_bin_weights[2];
+  
+  // Model DO time series
+  // * trapezoid version
+  // * observation error
+  // * no process error
+  // * reaeration depends on DO_obs
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  DO_mod[1] = DO_obs_1;
+  for(i in 1:(n-1)) {
+    DO_mod[i+1] =
+      DO_mod[i] + (
+        - KO2_inst[i] .* DO_obs[i] - KO2_inst[i+1] .* DO_obs[i+1] +
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        (GPP_inst[i+1] + ER_inst[i+1]) ./ depth[i+1] +
+        KO2_inst[i] .* DO_sat[i] + KO2_inst[i+1] .* DO_sat[i+1]
+      ) * (timestep / 2.0);
+  }
+}
+
+model {
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  K600_daily ~ normal(exp(K600_daily_predlog), K600_daily_sigma);
+  // Hierarchical constraints on K600_daily (binned_sdfixed model)
+  lnK600_lnQ_nodes ~ normal(K600_lnQ_nodes_meanlog, K600_lnQ_nodes_sdlog);
+  for(k in 2:b) {
+    lnK600_lnQ_nodes[k] ~ normal(lnK600_lnQ_nodes[k-1], K600_lnQ_nodediffs_sdlog);
+  }
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kbx_oipi_eu_plrckm.stan
+++ b/inst/models/b_Kbx_oipi_eu_plrckm.stan
@@ -1,0 +1,143 @@
+// b_Kbx_oipi_eu_plrckm.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (binned_sdfixed model)
+  int <lower=1> b; # number of K600_lnQ_nodes
+  real K600_lnQ_nodediffs_sdlog;
+  vector[b] K600_lnQ_nodes_meanlog;
+  vector[b] K600_lnQ_nodes_sdlog;
+  real<lower=0> K600_daily_sigma;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  int<lower=1,upper=b> lnQ_bins[2,d];
+  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  vector<lower=0>[d] K600_daily;
+  
+  vector[b] lnK600_lnQ_nodes;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+  real<lower=0> err_proc_iid_sigma_scaled;
+  vector[d] DO_mod[n];
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, binned_sdfixed model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_nodes[lnQ_bins[1]] .* lnQ_bin_weights[1] + 
+                       lnK600_lnQ_nodes[lnQ_bins[2]] .* lnQ_bin_weights[2];
+  
+  // Model DO time series
+  // * euler version
+  // * observation error
+  // * IID process error
+  // * reaeration depends on DO_mod
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_mod[i] + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        KO2_inst[i] .* (DO_sat[i] - DO_mod[i])
+      ) * timestep;
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        timestep ./ depth[i,j];
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_mod[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  K600_daily ~ normal(exp(K600_daily_predlog), K600_daily_sigma);
+  // Hierarchical constraints on K600_daily (binned_sdfixed model)
+  lnK600_lnQ_nodes ~ normal(K600_lnQ_nodes_meanlog, K600_lnQ_nodes_sdlog);
+  for(k in 2:b) {
+    lnK600_lnQ_nodes[k] ~ normal(lnK600_lnQ_nodes[k-1], K600_lnQ_nodediffs_sdlog);
+  }
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_mod[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kbx_oipi_eu_plrcko.stan
+++ b/inst/models/b_Kbx_oipi_eu_plrcko.stan
@@ -1,0 +1,143 @@
+// b_Kbx_oipi_eu_plrcko.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (binned_sdfixed model)
+  int <lower=1> b; # number of K600_lnQ_nodes
+  real K600_lnQ_nodediffs_sdlog;
+  vector[b] K600_lnQ_nodes_meanlog;
+  vector[b] K600_lnQ_nodes_sdlog;
+  real<lower=0> K600_daily_sigma;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  int<lower=1,upper=b> lnQ_bins[2,d];
+  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  vector<lower=0>[d] K600_daily;
+  
+  vector[b] lnK600_lnQ_nodes;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+  real<lower=0> err_proc_iid_sigma_scaled;
+  vector[d] DO_mod[n];
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, binned_sdfixed model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_nodes[lnQ_bins[1]] .* lnQ_bin_weights[1] + 
+                       lnK600_lnQ_nodes[lnQ_bins[2]] .* lnQ_bin_weights[2];
+  
+  // Model DO time series
+  // * euler version
+  // * observation error
+  // * IID process error
+  // * reaeration depends on DO_obs
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_mod[i] + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        KO2_inst[i] .* (DO_sat[i] - DO_obs[i])
+      ) * timestep;
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        timestep ./ depth[i,j];
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_mod[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  K600_daily ~ normal(exp(K600_daily_predlog), K600_daily_sigma);
+  // Hierarchical constraints on K600_daily (binned_sdfixed model)
+  lnK600_lnQ_nodes ~ normal(K600_lnQ_nodes_meanlog, K600_lnQ_nodes_sdlog);
+  for(k in 2:b) {
+    lnK600_lnQ_nodes[k] ~ normal(lnK600_lnQ_nodes[k-1], K600_lnQ_nodediffs_sdlog);
+  }
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_mod[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kbx_oipi_tr_plrckm.stan
+++ b/inst/models/b_Kbx_oipi_tr_plrckm.stan
@@ -1,0 +1,146 @@
+// b_Kbx_oipi_tr_plrckm.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (binned_sdfixed model)
+  int <lower=1> b; # number of K600_lnQ_nodes
+  real K600_lnQ_nodediffs_sdlog;
+  vector[b] K600_lnQ_nodes_meanlog;
+  vector[b] K600_lnQ_nodes_sdlog;
+  real<lower=0> K600_daily_sigma;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  int<lower=1,upper=b> lnQ_bins[2,d];
+  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  vector<lower=0>[d] K600_daily;
+  
+  vector[b] lnK600_lnQ_nodes;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+  real<lower=0> err_proc_iid_sigma_scaled;
+  vector[d] DO_mod[n];
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, binned_sdfixed model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_nodes[lnQ_bins[1]] .* lnQ_bin_weights[1] + 
+                       lnK600_lnQ_nodes[lnQ_bins[2]] .* lnQ_bin_weights[2];
+  
+  // Model DO time series
+  // * trapezoid version
+  // * observation error
+  // * IID process error
+  // * reaeration depends on DO_mod
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_mod[i] .*
+        (2.0 - KO2_inst[i] * timestep) ./ (2.0 + KO2_inst[i+1] * timestep) + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        (GPP_inst[i+1] + ER_inst[i+1]) ./ depth[i+1] +
+        KO2_inst[i] .* DO_sat[i] + KO2_inst[i+1] .* DO_sat[i+1]
+      ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_mod[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  K600_daily ~ normal(exp(K600_daily_predlog), K600_daily_sigma);
+  // Hierarchical constraints on K600_daily (binned_sdfixed model)
+  lnK600_lnQ_nodes ~ normal(K600_lnQ_nodes_meanlog, K600_lnQ_nodes_sdlog);
+  for(k in 2:b) {
+    lnK600_lnQ_nodes[k] ~ normal(lnK600_lnQ_nodes[k-1], K600_lnQ_nodediffs_sdlog);
+  }
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_mod[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kbx_oipi_tr_plrcko.stan
+++ b/inst/models/b_Kbx_oipi_tr_plrcko.stan
@@ -1,0 +1,146 @@
+// b_Kbx_oipi_tr_plrcko.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (binned_sdfixed model)
+  int <lower=1> b; # number of K600_lnQ_nodes
+  real K600_lnQ_nodediffs_sdlog;
+  vector[b] K600_lnQ_nodes_meanlog;
+  vector[b] K600_lnQ_nodes_sdlog;
+  real<lower=0> K600_daily_sigma;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  int<lower=1,upper=b> lnQ_bins[2,d];
+  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  vector<lower=0>[d] K600_daily;
+  
+  vector[b] lnK600_lnQ_nodes;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+  real<lower=0> err_proc_iid_sigma_scaled;
+  vector[d] DO_mod[n];
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, binned_sdfixed model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_nodes[lnQ_bins[1]] .* lnQ_bin_weights[1] + 
+                       lnK600_lnQ_nodes[lnQ_bins[2]] .* lnQ_bin_weights[2];
+  
+  // Model DO time series
+  // * trapezoid version
+  // * observation error
+  // * IID process error
+  // * reaeration depends on DO_obs
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_mod[i] + (
+        - KO2_inst[i] .* DO_obs[i] - KO2_inst[i+1] .* DO_obs[i+1] +
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        (GPP_inst[i+1] + ER_inst[i+1]) ./ depth[i+1] +
+        KO2_inst[i] .* DO_sat[i] + KO2_inst[i+1] .* DO_sat[i+1]
+      ) * (timestep / 2.0);
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        (timestep / 2.0);
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_mod[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  K600_daily ~ normal(exp(K600_daily_predlog), K600_daily_sigma);
+  // Hierarchical constraints on K600_daily (binned_sdfixed model)
+  lnK600_lnQ_nodes ~ normal(K600_lnQ_nodes_meanlog, K600_lnQ_nodes_sdlog);
+  for(k in 2:b) {
+    lnK600_lnQ_nodes[k] ~ normal(lnK600_lnQ_nodes[k-1], K600_lnQ_nodediffs_sdlog);
+  }
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_mod[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kbx_pi_eu_plrckm.stan
+++ b/inst/models/b_Kbx_pi_eu_plrckm.stan
@@ -1,0 +1,131 @@
+// b_Kbx_pi_eu_plrckm.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (binned_sdfixed model)
+  int <lower=1> b; # number of K600_lnQ_nodes
+  real K600_lnQ_nodediffs_sdlog;
+  vector[b] K600_lnQ_nodes_meanlog;
+  vector[b] K600_lnQ_nodes_sdlog;
+  real<lower=0> K600_daily_sigma;
+  
+  // Error distributions
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  int<lower=1,upper=b> lnQ_bins[2,d];
+  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  vector<lower=0>[d] K600_daily;
+  
+  vector[b] lnK600_lnQ_nodes;
+  
+  real<lower=0> err_proc_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, binned_sdfixed model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_nodes[lnQ_bins[1]] .* lnQ_bin_weights[1] + 
+                       lnK600_lnQ_nodes[lnQ_bins[2]] .* lnQ_bin_weights[2];
+  
+  // Model DO time series
+  // * euler version
+  // * no observation error
+  // * IID process error
+  // * reaeration depends on DO_mod
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  DO_mod_partial[1] = DO_obs_1;
+  DO_mod_partial_sigma[1] = err_proc_iid_sigma * timestep ./ depth[1];
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_obs[i] + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        KO2_inst[i] .* (DO_sat[i] - DO_mod_partial[i])
+      ) * timestep;
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        timestep ./ depth[i,j];
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_obs[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  K600_daily ~ normal(exp(K600_daily_predlog), K600_daily_sigma);
+  // Hierarchical constraints on K600_daily (binned_sdfixed model)
+  lnK600_lnQ_nodes ~ normal(K600_lnQ_nodes_meanlog, K600_lnQ_nodes_sdlog);
+  for(k in 2:b) {
+    lnK600_lnQ_nodes[k] ~ normal(lnK600_lnQ_nodes[k-1], K600_lnQ_nodediffs_sdlog);
+  }
+  
+}
+generated quantities {
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_obs[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kbx_pi_eu_plrcko.stan
+++ b/inst/models/b_Kbx_pi_eu_plrcko.stan
@@ -1,0 +1,129 @@
+// b_Kbx_pi_eu_plrcko.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (binned_sdfixed model)
+  int <lower=1> b; # number of K600_lnQ_nodes
+  real K600_lnQ_nodediffs_sdlog;
+  vector[b] K600_lnQ_nodes_meanlog;
+  vector[b] K600_lnQ_nodes_sdlog;
+  real<lower=0> K600_daily_sigma;
+  
+  // Error distributions
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  int<lower=1,upper=b> lnQ_bins[2,d];
+  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  vector<lower=0>[d] K600_daily;
+  
+  vector[b] lnK600_lnQ_nodes;
+  
+  real<lower=0> err_proc_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, binned_sdfixed model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_nodes[lnQ_bins[1]] .* lnQ_bin_weights[1] + 
+                       lnK600_lnQ_nodes[lnQ_bins[2]] .* lnQ_bin_weights[2];
+  
+  // Model DO time series
+  // * euler version
+  // * no observation error
+  // * IID process error
+  // * reaeration depends on DO_obs
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_obs[i] + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        KO2_inst[i] .* (DO_sat[i] - DO_obs[i])
+      ) * timestep;
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        timestep ./ depth[i,j];
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_obs[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  K600_daily ~ normal(exp(K600_daily_predlog), K600_daily_sigma);
+  // Hierarchical constraints on K600_daily (binned_sdfixed model)
+  lnK600_lnQ_nodes ~ normal(K600_lnQ_nodes_meanlog, K600_lnQ_nodes_sdlog);
+  for(k in 2:b) {
+    lnK600_lnQ_nodes[k] ~ normal(lnK600_lnQ_nodes[k-1], K600_lnQ_nodediffs_sdlog);
+  }
+  
+}
+generated quantities {
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_obs[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kbx_pi_tr_plrckm.stan
+++ b/inst/models/b_Kbx_pi_tr_plrckm.stan
@@ -1,0 +1,134 @@
+// b_Kbx_pi_tr_plrckm.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (binned_sdfixed model)
+  int <lower=1> b; # number of K600_lnQ_nodes
+  real K600_lnQ_nodediffs_sdlog;
+  vector[b] K600_lnQ_nodes_meanlog;
+  vector[b] K600_lnQ_nodes_sdlog;
+  real<lower=0> K600_daily_sigma;
+  
+  // Error distributions
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  int<lower=1,upper=b> lnQ_bins[2,d];
+  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  vector<lower=0>[d] K600_daily;
+  
+  vector[b] lnK600_lnQ_nodes;
+  
+  real<lower=0> err_proc_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, binned_sdfixed model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_nodes[lnQ_bins[1]] .* lnQ_bin_weights[1] + 
+                       lnK600_lnQ_nodes[lnQ_bins[2]] .* lnQ_bin_weights[2];
+  
+  // Model DO time series
+  // * trapezoid version
+  // * no observation error
+  // * IID process error
+  // * reaeration depends on DO_mod
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  DO_mod_partial[1] = DO_obs_1;
+  DO_mod_partial_sigma[1] = err_proc_iid_sigma * timestep ./ depth[1];
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_mod_partial[i] .*
+        (2.0 - KO2_inst[i] * timestep) ./ (2.0 + KO2_inst[i+1] * timestep) + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        (GPP_inst[i+1] + ER_inst[i+1]) ./ depth[i+1] +
+        KO2_inst[i] .* DO_sat[i] + KO2_inst[i+1] .* DO_sat[i+1]
+      ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_obs[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  K600_daily ~ normal(exp(K600_daily_predlog), K600_daily_sigma);
+  // Hierarchical constraints on K600_daily (binned_sdfixed model)
+  lnK600_lnQ_nodes ~ normal(K600_lnQ_nodes_meanlog, K600_lnQ_nodes_sdlog);
+  for(k in 2:b) {
+    lnK600_lnQ_nodes[k] ~ normal(lnK600_lnQ_nodes[k-1], K600_lnQ_nodediffs_sdlog);
+  }
+  
+}
+generated quantities {
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_obs[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kbx_pi_tr_plrcko.stan
+++ b/inst/models/b_Kbx_pi_tr_plrcko.stan
@@ -1,0 +1,132 @@
+// b_Kbx_pi_tr_plrcko.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (binned_sdfixed model)
+  int <lower=1> b; # number of K600_lnQ_nodes
+  real K600_lnQ_nodediffs_sdlog;
+  vector[b] K600_lnQ_nodes_meanlog;
+  vector[b] K600_lnQ_nodes_sdlog;
+  real<lower=0> K600_daily_sigma;
+  
+  // Error distributions
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  int<lower=1,upper=b> lnQ_bins[2,d];
+  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  vector<lower=0>[d] K600_daily;
+  
+  vector[b] lnK600_lnQ_nodes;
+  
+  real<lower=0> err_proc_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, binned_sdfixed model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_nodes[lnQ_bins[1]] .* lnQ_bin_weights[1] + 
+                       lnK600_lnQ_nodes[lnQ_bins[2]] .* lnQ_bin_weights[2];
+  
+  // Model DO time series
+  // * trapezoid version
+  // * no observation error
+  // * IID process error
+  // * reaeration depends on DO_obs
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_obs[i] + (
+        - KO2_inst[i] .* DO_obs[i] - KO2_inst[i+1] .* DO_obs[i+1] +
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        (GPP_inst[i+1] + ER_inst[i+1]) ./ depth[i+1] +
+        KO2_inst[i] .* DO_sat[i] + KO2_inst[i+1] .* DO_sat[i+1]
+      ) * (timestep / 2.0);
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        (timestep / 2.0);
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_obs[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  K600_daily ~ normal(exp(K600_daily_predlog), K600_daily_sigma);
+  // Hierarchical constraints on K600_daily (binned_sdfixed model)
+  lnK600_lnQ_nodes ~ normal(K600_lnQ_nodes_meanlog, K600_lnQ_nodes_sdlog);
+  for(k in 2:b) {
+    lnK600_lnQ_nodes[k] ~ normal(lnK600_lnQ_nodes[k-1], K600_lnQ_nodediffs_sdlog);
+  }
+  
+}
+generated quantities {
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_obs[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kl0_oi_eu_plrckm.stan
+++ b/inst/models/b_Kl0_oi_eu_plrckm.stan
@@ -1,0 +1,120 @@
+// b_Kl0_oi_eu_plrckm.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (linear_sdzero model)
+  real lnK600_lnQ_intercept_mu;
+  real<lower=0> lnK600_lnQ_intercept_sigma;
+  real lnK600_lnQ_slope_mu;
+  real<lower=0> lnK600_lnQ_slope_sigma;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  vector[d] lnQ_daily;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  
+  real lnK600_lnQ_intercept;
+  real lnK600_lnQ_slope;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  vector[d] K600_daily;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  
+  // Hierarchical, linear_sdzero model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_intercept + lnK600_lnQ_slope * lnQ_daily;
+  K600_daily = exp(K600_daily_predlog);
+  
+  // Model DO time series
+  // * euler version
+  // * observation error
+  // * no process error
+  // * reaeration depends on DO_mod
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  DO_mod[1] = DO_obs_1;
+  for(i in 1:(n-1)) {
+    DO_mod[i+1] =
+      DO_mod[i] + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        KO2_inst[i] .* (DO_sat[i] - DO_mod[i])
+      ) * timestep;
+  }
+}
+
+model {
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  // Hierarchical constraints on K600_daily (linear_sdzero model)
+  lnK600_lnQ_intercept ~ normal(lnK600_lnQ_intercept_mu, lnK600_lnQ_intercept_sigma);
+  lnK600_lnQ_slope ~ normal(lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma);
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kl0_oi_eu_plrcko.stan
+++ b/inst/models/b_Kl0_oi_eu_plrcko.stan
@@ -1,0 +1,120 @@
+// b_Kl0_oi_eu_plrcko.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (linear_sdzero model)
+  real lnK600_lnQ_intercept_mu;
+  real<lower=0> lnK600_lnQ_intercept_sigma;
+  real lnK600_lnQ_slope_mu;
+  real<lower=0> lnK600_lnQ_slope_sigma;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  vector[d] lnQ_daily;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  
+  real lnK600_lnQ_intercept;
+  real lnK600_lnQ_slope;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  vector[d] K600_daily;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  
+  // Hierarchical, linear_sdzero model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_intercept + lnK600_lnQ_slope * lnQ_daily;
+  K600_daily = exp(K600_daily_predlog);
+  
+  // Model DO time series
+  // * euler version
+  // * observation error
+  // * no process error
+  // * reaeration depends on DO_obs
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  DO_mod[1] = DO_obs_1;
+  for(i in 1:(n-1)) {
+    DO_mod[i+1] =
+      DO_mod[i] + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        KO2_inst[i] .* (DO_sat[i] - DO_obs[i])
+      ) * timestep;
+  }
+}
+
+model {
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  // Hierarchical constraints on K600_daily (linear_sdzero model)
+  lnK600_lnQ_intercept ~ normal(lnK600_lnQ_intercept_mu, lnK600_lnQ_intercept_sigma);
+  lnK600_lnQ_slope ~ normal(lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma);
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kl0_oi_tr_plrckm.stan
+++ b/inst/models/b_Kl0_oi_tr_plrckm.stan
@@ -1,0 +1,122 @@
+// b_Kl0_oi_tr_plrckm.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (linear_sdzero model)
+  real lnK600_lnQ_intercept_mu;
+  real<lower=0> lnK600_lnQ_intercept_sigma;
+  real lnK600_lnQ_slope_mu;
+  real<lower=0> lnK600_lnQ_slope_sigma;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  vector[d] lnQ_daily;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  
+  real lnK600_lnQ_intercept;
+  real lnK600_lnQ_slope;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  vector[d] K600_daily;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  
+  // Hierarchical, linear_sdzero model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_intercept + lnK600_lnQ_slope * lnQ_daily;
+  K600_daily = exp(K600_daily_predlog);
+  
+  // Model DO time series
+  // * trapezoid version
+  // * observation error
+  // * no process error
+  // * reaeration depends on DO_mod
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  DO_mod[1] = DO_obs_1;
+  for(i in 1:(n-1)) {
+    DO_mod[i+1] =
+      DO_mod[i] .*
+        (2.0 - KO2_inst[i] * timestep) ./ (2.0 + KO2_inst[i+1] * timestep) + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        (GPP_inst[i+1] + ER_inst[i+1]) ./ depth[i+1] +
+        KO2_inst[i] .* DO_sat[i] + KO2_inst[i+1] .* DO_sat[i+1]
+      ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
+  }
+}
+
+model {
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  // Hierarchical constraints on K600_daily (linear_sdzero model)
+  lnK600_lnQ_intercept ~ normal(lnK600_lnQ_intercept_mu, lnK600_lnQ_intercept_sigma);
+  lnK600_lnQ_slope ~ normal(lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma);
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kl0_oi_tr_plrcko.stan
+++ b/inst/models/b_Kl0_oi_tr_plrcko.stan
@@ -1,0 +1,122 @@
+// b_Kl0_oi_tr_plrcko.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (linear_sdzero model)
+  real lnK600_lnQ_intercept_mu;
+  real<lower=0> lnK600_lnQ_intercept_sigma;
+  real lnK600_lnQ_slope_mu;
+  real<lower=0> lnK600_lnQ_slope_sigma;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  vector[d] lnQ_daily;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  
+  real lnK600_lnQ_intercept;
+  real lnK600_lnQ_slope;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  vector[d] K600_daily;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  
+  // Hierarchical, linear_sdzero model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_intercept + lnK600_lnQ_slope * lnQ_daily;
+  K600_daily = exp(K600_daily_predlog);
+  
+  // Model DO time series
+  // * trapezoid version
+  // * observation error
+  // * no process error
+  // * reaeration depends on DO_obs
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  DO_mod[1] = DO_obs_1;
+  for(i in 1:(n-1)) {
+    DO_mod[i+1] =
+      DO_mod[i] + (
+        - KO2_inst[i] .* DO_obs[i] - KO2_inst[i+1] .* DO_obs[i+1] +
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        (GPP_inst[i+1] + ER_inst[i+1]) ./ depth[i+1] +
+        KO2_inst[i] .* DO_sat[i] + KO2_inst[i+1] .* DO_sat[i+1]
+      ) * (timestep / 2.0);
+  }
+}
+
+model {
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  // Hierarchical constraints on K600_daily (linear_sdzero model)
+  lnK600_lnQ_intercept ~ normal(lnK600_lnQ_intercept_mu, lnK600_lnQ_intercept_sigma);
+  lnK600_lnQ_slope ~ normal(lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma);
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kl0_oipi_eu_plrckm.stan
+++ b/inst/models/b_Kl0_oipi_eu_plrckm.stan
@@ -1,0 +1,139 @@
+// b_Kl0_oipi_eu_plrckm.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (linear_sdzero model)
+  real lnK600_lnQ_intercept_mu;
+  real<lower=0> lnK600_lnQ_intercept_sigma;
+  real lnK600_lnQ_slope_mu;
+  real<lower=0> lnK600_lnQ_slope_sigma;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  vector[d] lnQ_daily;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  
+  real lnK600_lnQ_intercept;
+  real lnK600_lnQ_slope;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+  real<lower=0> err_proc_iid_sigma_scaled;
+  vector[d] DO_mod[n];
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  vector[d] K600_daily;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, linear_sdzero model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_intercept + lnK600_lnQ_slope * lnQ_daily;
+  K600_daily = exp(K600_daily_predlog);
+  
+  // Model DO time series
+  // * euler version
+  // * observation error
+  // * IID process error
+  // * reaeration depends on DO_mod
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_mod[i] + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        KO2_inst[i] .* (DO_sat[i] - DO_mod[i])
+      ) * timestep;
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        timestep ./ depth[i,j];
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_mod[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  // Hierarchical constraints on K600_daily (linear_sdzero model)
+  lnK600_lnQ_intercept ~ normal(lnK600_lnQ_intercept_mu, lnK600_lnQ_intercept_sigma);
+  lnK600_lnQ_slope ~ normal(lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma);
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_mod[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kl0_oipi_eu_plrcko.stan
+++ b/inst/models/b_Kl0_oipi_eu_plrcko.stan
@@ -1,0 +1,139 @@
+// b_Kl0_oipi_eu_plrcko.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (linear_sdzero model)
+  real lnK600_lnQ_intercept_mu;
+  real<lower=0> lnK600_lnQ_intercept_sigma;
+  real lnK600_lnQ_slope_mu;
+  real<lower=0> lnK600_lnQ_slope_sigma;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  vector[d] lnQ_daily;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  
+  real lnK600_lnQ_intercept;
+  real lnK600_lnQ_slope;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+  real<lower=0> err_proc_iid_sigma_scaled;
+  vector[d] DO_mod[n];
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  vector[d] K600_daily;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, linear_sdzero model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_intercept + lnK600_lnQ_slope * lnQ_daily;
+  K600_daily = exp(K600_daily_predlog);
+  
+  // Model DO time series
+  // * euler version
+  // * observation error
+  // * IID process error
+  // * reaeration depends on DO_obs
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_mod[i] + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        KO2_inst[i] .* (DO_sat[i] - DO_obs[i])
+      ) * timestep;
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        timestep ./ depth[i,j];
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_mod[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  // Hierarchical constraints on K600_daily (linear_sdzero model)
+  lnK600_lnQ_intercept ~ normal(lnK600_lnQ_intercept_mu, lnK600_lnQ_intercept_sigma);
+  lnK600_lnQ_slope ~ normal(lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma);
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_mod[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kl0_oipi_tr_plrckm.stan
+++ b/inst/models/b_Kl0_oipi_tr_plrckm.stan
@@ -1,0 +1,142 @@
+// b_Kl0_oipi_tr_plrckm.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (linear_sdzero model)
+  real lnK600_lnQ_intercept_mu;
+  real<lower=0> lnK600_lnQ_intercept_sigma;
+  real lnK600_lnQ_slope_mu;
+  real<lower=0> lnK600_lnQ_slope_sigma;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  vector[d] lnQ_daily;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  
+  real lnK600_lnQ_intercept;
+  real lnK600_lnQ_slope;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+  real<lower=0> err_proc_iid_sigma_scaled;
+  vector[d] DO_mod[n];
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  vector[d] K600_daily;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, linear_sdzero model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_intercept + lnK600_lnQ_slope * lnQ_daily;
+  K600_daily = exp(K600_daily_predlog);
+  
+  // Model DO time series
+  // * trapezoid version
+  // * observation error
+  // * IID process error
+  // * reaeration depends on DO_mod
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_mod[i] .*
+        (2.0 - KO2_inst[i] * timestep) ./ (2.0 + KO2_inst[i+1] * timestep) + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        (GPP_inst[i+1] + ER_inst[i+1]) ./ depth[i+1] +
+        KO2_inst[i] .* DO_sat[i] + KO2_inst[i+1] .* DO_sat[i+1]
+      ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_mod[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  // Hierarchical constraints on K600_daily (linear_sdzero model)
+  lnK600_lnQ_intercept ~ normal(lnK600_lnQ_intercept_mu, lnK600_lnQ_intercept_sigma);
+  lnK600_lnQ_slope ~ normal(lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma);
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_mod[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kl0_oipi_tr_plrcko.stan
+++ b/inst/models/b_Kl0_oipi_tr_plrcko.stan
@@ -1,0 +1,142 @@
+// b_Kl0_oipi_tr_plrcko.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (linear_sdzero model)
+  real lnK600_lnQ_intercept_mu;
+  real<lower=0> lnK600_lnQ_intercept_sigma;
+  real lnK600_lnQ_slope_mu;
+  real<lower=0> lnK600_lnQ_slope_sigma;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  vector[d] lnQ_daily;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  
+  real lnK600_lnQ_intercept;
+  real lnK600_lnQ_slope;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+  real<lower=0> err_proc_iid_sigma_scaled;
+  vector[d] DO_mod[n];
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  vector[d] K600_daily;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, linear_sdzero model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_intercept + lnK600_lnQ_slope * lnQ_daily;
+  K600_daily = exp(K600_daily_predlog);
+  
+  // Model DO time series
+  // * trapezoid version
+  // * observation error
+  // * IID process error
+  // * reaeration depends on DO_obs
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_mod[i] + (
+        - KO2_inst[i] .* DO_obs[i] - KO2_inst[i+1] .* DO_obs[i+1] +
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        (GPP_inst[i+1] + ER_inst[i+1]) ./ depth[i+1] +
+        KO2_inst[i] .* DO_sat[i] + KO2_inst[i+1] .* DO_sat[i+1]
+      ) * (timestep / 2.0);
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        (timestep / 2.0);
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_mod[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  // Hierarchical constraints on K600_daily (linear_sdzero model)
+  lnK600_lnQ_intercept ~ normal(lnK600_lnQ_intercept_mu, lnK600_lnQ_intercept_sigma);
+  lnK600_lnQ_slope ~ normal(lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma);
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_mod[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kl0_pi_eu_plrckm.stan
+++ b/inst/models/b_Kl0_pi_eu_plrckm.stan
@@ -1,0 +1,127 @@
+// b_Kl0_pi_eu_plrckm.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (linear_sdzero model)
+  real lnK600_lnQ_intercept_mu;
+  real<lower=0> lnK600_lnQ_intercept_sigma;
+  real lnK600_lnQ_slope_mu;
+  real<lower=0> lnK600_lnQ_slope_sigma;
+  
+  // Error distributions
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  vector[d] lnQ_daily;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  
+  real lnK600_lnQ_intercept;
+  real lnK600_lnQ_slope;
+  
+  real<lower=0> err_proc_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  vector[d] K600_daily;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, linear_sdzero model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_intercept + lnK600_lnQ_slope * lnQ_daily;
+  K600_daily = exp(K600_daily_predlog);
+  
+  // Model DO time series
+  // * euler version
+  // * no observation error
+  // * IID process error
+  // * reaeration depends on DO_mod
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  DO_mod_partial[1] = DO_obs_1;
+  DO_mod_partial_sigma[1] = err_proc_iid_sigma * timestep ./ depth[1];
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_obs[i] + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        KO2_inst[i] .* (DO_sat[i] - DO_mod_partial[i])
+      ) * timestep;
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        timestep ./ depth[i,j];
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_obs[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  // Hierarchical constraints on K600_daily (linear_sdzero model)
+  lnK600_lnQ_intercept ~ normal(lnK600_lnQ_intercept_mu, lnK600_lnQ_intercept_sigma);
+  lnK600_lnQ_slope ~ normal(lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma);
+  
+}
+generated quantities {
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_obs[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kl0_pi_eu_plrcko.stan
+++ b/inst/models/b_Kl0_pi_eu_plrcko.stan
@@ -1,0 +1,125 @@
+// b_Kl0_pi_eu_plrcko.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (linear_sdzero model)
+  real lnK600_lnQ_intercept_mu;
+  real<lower=0> lnK600_lnQ_intercept_sigma;
+  real lnK600_lnQ_slope_mu;
+  real<lower=0> lnK600_lnQ_slope_sigma;
+  
+  // Error distributions
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  vector[d] lnQ_daily;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  
+  real lnK600_lnQ_intercept;
+  real lnK600_lnQ_slope;
+  
+  real<lower=0> err_proc_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  vector[d] K600_daily;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, linear_sdzero model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_intercept + lnK600_lnQ_slope * lnQ_daily;
+  K600_daily = exp(K600_daily_predlog);
+  
+  // Model DO time series
+  // * euler version
+  // * no observation error
+  // * IID process error
+  // * reaeration depends on DO_obs
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_obs[i] + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        KO2_inst[i] .* (DO_sat[i] - DO_obs[i])
+      ) * timestep;
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        timestep ./ depth[i,j];
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_obs[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  // Hierarchical constraints on K600_daily (linear_sdzero model)
+  lnK600_lnQ_intercept ~ normal(lnK600_lnQ_intercept_mu, lnK600_lnQ_intercept_sigma);
+  lnK600_lnQ_slope ~ normal(lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma);
+  
+}
+generated quantities {
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_obs[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kl0_pi_tr_plrckm.stan
+++ b/inst/models/b_Kl0_pi_tr_plrckm.stan
@@ -1,0 +1,130 @@
+// b_Kl0_pi_tr_plrckm.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (linear_sdzero model)
+  real lnK600_lnQ_intercept_mu;
+  real<lower=0> lnK600_lnQ_intercept_sigma;
+  real lnK600_lnQ_slope_mu;
+  real<lower=0> lnK600_lnQ_slope_sigma;
+  
+  // Error distributions
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  vector[d] lnQ_daily;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  
+  real lnK600_lnQ_intercept;
+  real lnK600_lnQ_slope;
+  
+  real<lower=0> err_proc_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  vector[d] K600_daily;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, linear_sdzero model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_intercept + lnK600_lnQ_slope * lnQ_daily;
+  K600_daily = exp(K600_daily_predlog);
+  
+  // Model DO time series
+  // * trapezoid version
+  // * no observation error
+  // * IID process error
+  // * reaeration depends on DO_mod
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  DO_mod_partial[1] = DO_obs_1;
+  DO_mod_partial_sigma[1] = err_proc_iid_sigma * timestep ./ depth[1];
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_mod_partial[i] .*
+        (2.0 - KO2_inst[i] * timestep) ./ (2.0 + KO2_inst[i+1] * timestep) + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        (GPP_inst[i+1] + ER_inst[i+1]) ./ depth[i+1] +
+        KO2_inst[i] .* DO_sat[i] + KO2_inst[i+1] .* DO_sat[i+1]
+      ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_obs[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  // Hierarchical constraints on K600_daily (linear_sdzero model)
+  lnK600_lnQ_intercept ~ normal(lnK600_lnQ_intercept_mu, lnK600_lnQ_intercept_sigma);
+  lnK600_lnQ_slope ~ normal(lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma);
+  
+}
+generated quantities {
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_obs[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kl0_pi_tr_plrcko.stan
+++ b/inst/models/b_Kl0_pi_tr_plrcko.stan
@@ -1,0 +1,128 @@
+// b_Kl0_pi_tr_plrcko.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (linear_sdzero model)
+  real lnK600_lnQ_intercept_mu;
+  real<lower=0> lnK600_lnQ_intercept_sigma;
+  real lnK600_lnQ_slope_mu;
+  real<lower=0> lnK600_lnQ_slope_sigma;
+  
+  // Error distributions
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  vector[d] lnQ_daily;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  
+  real lnK600_lnQ_intercept;
+  real lnK600_lnQ_slope;
+  
+  real<lower=0> err_proc_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  vector[d] K600_daily;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, linear_sdzero model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_intercept + lnK600_lnQ_slope * lnQ_daily;
+  K600_daily = exp(K600_daily_predlog);
+  
+  // Model DO time series
+  // * trapezoid version
+  // * no observation error
+  // * IID process error
+  // * reaeration depends on DO_obs
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_obs[i] + (
+        - KO2_inst[i] .* DO_obs[i] - KO2_inst[i+1] .* DO_obs[i+1] +
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        (GPP_inst[i+1] + ER_inst[i+1]) ./ depth[i+1] +
+        KO2_inst[i] .* DO_sat[i] + KO2_inst[i+1] .* DO_sat[i+1]
+      ) * (timestep / 2.0);
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        (timestep / 2.0);
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_obs[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  // Hierarchical constraints on K600_daily (linear_sdzero model)
+  lnK600_lnQ_intercept ~ normal(lnK600_lnQ_intercept_mu, lnK600_lnQ_intercept_sigma);
+  lnK600_lnQ_slope ~ normal(lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma);
+  
+}
+generated quantities {
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_obs[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kl_oi_eu_plrckm.stan
+++ b/inst/models/b_Kl_oi_eu_plrckm.stan
@@ -14,7 +14,7 @@ data {
   real<lower=0> lnK600_lnQ_intercept_sigma;
   real lnK600_lnQ_slope_mu;
   real<lower=0> lnK600_lnQ_slope_sigma;
-  real<lower=0> K600_daily_sigma;
+  real<lower=0> K600_daily_sigma_sigma;
   
   // Error distributions
   real<lower=0> err_obs_iid_sigma_scale;
@@ -46,17 +46,22 @@ parameters {
   
   real lnK600_lnQ_intercept;
   real lnK600_lnQ_slope;
+  real<lower=0> K600_daily_sigma_scaled;
   
   real<lower=0> err_obs_iid_sigma_scaled;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
+  real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
   vector[d] GPP_inst[n];
   vector[d] ER_inst[n];
   vector[d] KO2_inst[n];
   vector[d] DO_mod[n];
+  
+  // Rescale pooling distribution parameter
+  K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -103,6 +108,7 @@ model {
   // Hierarchical constraints on K600_daily (linear model)
   lnK600_lnQ_intercept ~ normal(lnK600_lnQ_intercept_mu, lnK600_lnQ_intercept_sigma);
   lnK600_lnQ_slope ~ normal(lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma);
+  K600_daily_sigma_scaled ~ normal(0, 1);
   
 }
 generated quantities {

--- a/inst/models/b_Kl_oi_eu_plrcko.stan
+++ b/inst/models/b_Kl_oi_eu_plrcko.stan
@@ -14,7 +14,7 @@ data {
   real<lower=0> lnK600_lnQ_intercept_sigma;
   real lnK600_lnQ_slope_mu;
   real<lower=0> lnK600_lnQ_slope_sigma;
-  real<lower=0> K600_daily_sigma;
+  real<lower=0> K600_daily_sigma_sigma;
   
   // Error distributions
   real<lower=0> err_obs_iid_sigma_scale;
@@ -46,17 +46,22 @@ parameters {
   
   real lnK600_lnQ_intercept;
   real lnK600_lnQ_slope;
+  real<lower=0> K600_daily_sigma_scaled;
   
   real<lower=0> err_obs_iid_sigma_scaled;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
+  real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
   vector[d] GPP_inst[n];
   vector[d] ER_inst[n];
   vector[d] KO2_inst[n];
   vector[d] DO_mod[n];
+  
+  // Rescale pooling distribution parameter
+  K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -103,6 +108,7 @@ model {
   // Hierarchical constraints on K600_daily (linear model)
   lnK600_lnQ_intercept ~ normal(lnK600_lnQ_intercept_mu, lnK600_lnQ_intercept_sigma);
   lnK600_lnQ_slope ~ normal(lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma);
+  K600_daily_sigma_scaled ~ normal(0, 1);
   
 }
 generated quantities {

--- a/inst/models/b_Kl_oi_tr_plrckm.stan
+++ b/inst/models/b_Kl_oi_tr_plrckm.stan
@@ -14,7 +14,7 @@ data {
   real<lower=0> lnK600_lnQ_intercept_sigma;
   real lnK600_lnQ_slope_mu;
   real<lower=0> lnK600_lnQ_slope_sigma;
-  real<lower=0> K600_daily_sigma;
+  real<lower=0> K600_daily_sigma_sigma;
   
   // Error distributions
   real<lower=0> err_obs_iid_sigma_scale;
@@ -46,17 +46,22 @@ parameters {
   
   real lnK600_lnQ_intercept;
   real lnK600_lnQ_slope;
+  real<lower=0> K600_daily_sigma_scaled;
   
   real<lower=0> err_obs_iid_sigma_scaled;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
+  real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
   vector[d] GPP_inst[n];
   vector[d] ER_inst[n];
   vector[d] KO2_inst[n];
   vector[d] DO_mod[n];
+  
+  // Rescale pooling distribution parameter
+  K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -105,6 +110,7 @@ model {
   // Hierarchical constraints on K600_daily (linear model)
   lnK600_lnQ_intercept ~ normal(lnK600_lnQ_intercept_mu, lnK600_lnQ_intercept_sigma);
   lnK600_lnQ_slope ~ normal(lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma);
+  K600_daily_sigma_scaled ~ normal(0, 1);
   
 }
 generated quantities {

--- a/inst/models/b_Kl_oi_tr_plrcko.stan
+++ b/inst/models/b_Kl_oi_tr_plrcko.stan
@@ -14,7 +14,7 @@ data {
   real<lower=0> lnK600_lnQ_intercept_sigma;
   real lnK600_lnQ_slope_mu;
   real<lower=0> lnK600_lnQ_slope_sigma;
-  real<lower=0> K600_daily_sigma;
+  real<lower=0> K600_daily_sigma_sigma;
   
   // Error distributions
   real<lower=0> err_obs_iid_sigma_scale;
@@ -46,17 +46,22 @@ parameters {
   
   real lnK600_lnQ_intercept;
   real lnK600_lnQ_slope;
+  real<lower=0> K600_daily_sigma_scaled;
   
   real<lower=0> err_obs_iid_sigma_scaled;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
+  real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
   vector[d] GPP_inst[n];
   vector[d] ER_inst[n];
   vector[d] KO2_inst[n];
   vector[d] DO_mod[n];
+  
+  // Rescale pooling distribution parameter
+  K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -105,6 +110,7 @@ model {
   // Hierarchical constraints on K600_daily (linear model)
   lnK600_lnQ_intercept ~ normal(lnK600_lnQ_intercept_mu, lnK600_lnQ_intercept_sigma);
   lnK600_lnQ_slope ~ normal(lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma);
+  K600_daily_sigma_scaled ~ normal(0, 1);
   
 }
 generated quantities {

--- a/inst/models/b_Kl_oipi_eu_plrckm.stan
+++ b/inst/models/b_Kl_oipi_eu_plrckm.stan
@@ -14,7 +14,7 @@ data {
   real<lower=0> lnK600_lnQ_intercept_sigma;
   real lnK600_lnQ_slope_mu;
   real<lower=0> lnK600_lnQ_slope_sigma;
-  real<lower=0> K600_daily_sigma;
+  real<lower=0> K600_daily_sigma_sigma;
   
   // Error distributions
   real<lower=0> err_obs_iid_sigma_scale;
@@ -47,6 +47,7 @@ parameters {
   
   real lnK600_lnQ_intercept;
   real lnK600_lnQ_slope;
+  real<lower=0> K600_daily_sigma_scaled;
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
@@ -55,6 +56,7 @@ parameters {
 
 transformed parameters {
   vector[d] K600_daily_predlog;
+  real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
   vector[d] DO_mod_partial_sigma[n];
   real<lower=0> err_proc_iid_sigma;
@@ -62,6 +64,9 @@ transformed parameters {
   vector[d] ER_inst[n];
   vector[d] KO2_inst[n];
   vector[d] DO_mod_partial[n];
+  
+  // Rescale pooling distribution parameter
+  K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -120,6 +125,7 @@ model {
   // Hierarchical constraints on K600_daily (linear model)
   lnK600_lnQ_intercept ~ normal(lnK600_lnQ_intercept_mu, lnK600_lnQ_intercept_sigma);
   lnK600_lnQ_slope ~ normal(lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma);
+  K600_daily_sigma_scaled ~ normal(0, 1);
   
 }
 generated quantities {

--- a/inst/models/b_Kl_oipi_eu_plrcko.stan
+++ b/inst/models/b_Kl_oipi_eu_plrcko.stan
@@ -14,7 +14,7 @@ data {
   real<lower=0> lnK600_lnQ_intercept_sigma;
   real lnK600_lnQ_slope_mu;
   real<lower=0> lnK600_lnQ_slope_sigma;
-  real<lower=0> K600_daily_sigma;
+  real<lower=0> K600_daily_sigma_sigma;
   
   // Error distributions
   real<lower=0> err_obs_iid_sigma_scale;
@@ -47,6 +47,7 @@ parameters {
   
   real lnK600_lnQ_intercept;
   real lnK600_lnQ_slope;
+  real<lower=0> K600_daily_sigma_scaled;
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
@@ -55,6 +56,7 @@ parameters {
 
 transformed parameters {
   vector[d] K600_daily_predlog;
+  real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
   vector[d] DO_mod_partial_sigma[n];
   real<lower=0> err_proc_iid_sigma;
@@ -62,6 +64,9 @@ transformed parameters {
   vector[d] ER_inst[n];
   vector[d] KO2_inst[n];
   vector[d] DO_mod_partial[n];
+  
+  // Rescale pooling distribution parameter
+  K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -120,6 +125,7 @@ model {
   // Hierarchical constraints on K600_daily (linear model)
   lnK600_lnQ_intercept ~ normal(lnK600_lnQ_intercept_mu, lnK600_lnQ_intercept_sigma);
   lnK600_lnQ_slope ~ normal(lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma);
+  K600_daily_sigma_scaled ~ normal(0, 1);
   
 }
 generated quantities {

--- a/inst/models/b_Kl_oipi_tr_plrckm.stan
+++ b/inst/models/b_Kl_oipi_tr_plrckm.stan
@@ -14,7 +14,7 @@ data {
   real<lower=0> lnK600_lnQ_intercept_sigma;
   real lnK600_lnQ_slope_mu;
   real<lower=0> lnK600_lnQ_slope_sigma;
-  real<lower=0> K600_daily_sigma;
+  real<lower=0> K600_daily_sigma_sigma;
   
   // Error distributions
   real<lower=0> err_obs_iid_sigma_scale;
@@ -47,6 +47,7 @@ parameters {
   
   real lnK600_lnQ_intercept;
   real lnK600_lnQ_slope;
+  real<lower=0> K600_daily_sigma_scaled;
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
@@ -55,6 +56,7 @@ parameters {
 
 transformed parameters {
   vector[d] K600_daily_predlog;
+  real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
   vector[d] DO_mod_partial_sigma[n];
   real<lower=0> err_proc_iid_sigma;
@@ -62,6 +64,9 @@ transformed parameters {
   vector[d] ER_inst[n];
   vector[d] KO2_inst[n];
   vector[d] DO_mod_partial[n];
+  
+  // Rescale pooling distribution parameter
+  K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -123,6 +128,7 @@ model {
   // Hierarchical constraints on K600_daily (linear model)
   lnK600_lnQ_intercept ~ normal(lnK600_lnQ_intercept_mu, lnK600_lnQ_intercept_sigma);
   lnK600_lnQ_slope ~ normal(lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma);
+  K600_daily_sigma_scaled ~ normal(0, 1);
   
 }
 generated quantities {

--- a/inst/models/b_Kl_oipi_tr_plrcko.stan
+++ b/inst/models/b_Kl_oipi_tr_plrcko.stan
@@ -14,7 +14,7 @@ data {
   real<lower=0> lnK600_lnQ_intercept_sigma;
   real lnK600_lnQ_slope_mu;
   real<lower=0> lnK600_lnQ_slope_sigma;
-  real<lower=0> K600_daily_sigma;
+  real<lower=0> K600_daily_sigma_sigma;
   
   // Error distributions
   real<lower=0> err_obs_iid_sigma_scale;
@@ -47,6 +47,7 @@ parameters {
   
   real lnK600_lnQ_intercept;
   real lnK600_lnQ_slope;
+  real<lower=0> K600_daily_sigma_scaled;
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
@@ -55,6 +56,7 @@ parameters {
 
 transformed parameters {
   vector[d] K600_daily_predlog;
+  real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
   vector[d] DO_mod_partial_sigma[n];
   real<lower=0> err_proc_iid_sigma;
@@ -62,6 +64,9 @@ transformed parameters {
   vector[d] ER_inst[n];
   vector[d] KO2_inst[n];
   vector[d] DO_mod_partial[n];
+  
+  // Rescale pooling distribution parameter
+  K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -123,6 +128,7 @@ model {
   // Hierarchical constraints on K600_daily (linear model)
   lnK600_lnQ_intercept ~ normal(lnK600_lnQ_intercept_mu, lnK600_lnQ_intercept_sigma);
   lnK600_lnQ_slope ~ normal(lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma);
+  K600_daily_sigma_scaled ~ normal(0, 1);
   
 }
 generated quantities {

--- a/inst/models/b_Kl_pi_eu_plrckm.stan
+++ b/inst/models/b_Kl_pi_eu_plrckm.stan
@@ -14,7 +14,7 @@ data {
   real<lower=0> lnK600_lnQ_intercept_sigma;
   real lnK600_lnQ_slope_mu;
   real<lower=0> lnK600_lnQ_slope_sigma;
-  real<lower=0> K600_daily_sigma;
+  real<lower=0> K600_daily_sigma_sigma;
   
   // Error distributions
   real<lower=0> err_proc_iid_sigma_scale;
@@ -46,18 +46,23 @@ parameters {
   
   real lnK600_lnQ_intercept;
   real lnK600_lnQ_slope;
+  real<lower=0> K600_daily_sigma_scaled;
   
   real<lower=0> err_proc_iid_sigma_scaled;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
+  real<lower=0> K600_daily_sigma;
   vector[d] DO_mod_partial_sigma[n];
   real<lower=0> err_proc_iid_sigma;
   vector[d] GPP_inst[n];
   vector[d] ER_inst[n];
   vector[d] KO2_inst[n];
   vector[d] DO_mod_partial[n];
+  
+  // Rescale pooling distribution parameter
+  K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -110,6 +115,7 @@ model {
   // Hierarchical constraints on K600_daily (linear model)
   lnK600_lnQ_intercept ~ normal(lnK600_lnQ_intercept_mu, lnK600_lnQ_intercept_sigma);
   lnK600_lnQ_slope ~ normal(lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma);
+  K600_daily_sigma_scaled ~ normal(0, 1);
   
 }
 generated quantities {

--- a/inst/models/b_Kl_pi_eu_plrcko.stan
+++ b/inst/models/b_Kl_pi_eu_plrcko.stan
@@ -14,7 +14,7 @@ data {
   real<lower=0> lnK600_lnQ_intercept_sigma;
   real lnK600_lnQ_slope_mu;
   real<lower=0> lnK600_lnQ_slope_sigma;
-  real<lower=0> K600_daily_sigma;
+  real<lower=0> K600_daily_sigma_sigma;
   
   // Error distributions
   real<lower=0> err_proc_iid_sigma_scale;
@@ -46,18 +46,23 @@ parameters {
   
   real lnK600_lnQ_intercept;
   real lnK600_lnQ_slope;
+  real<lower=0> K600_daily_sigma_scaled;
   
   real<lower=0> err_proc_iid_sigma_scaled;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
+  real<lower=0> K600_daily_sigma;
   vector[d] DO_mod_partial_sigma[n];
   real<lower=0> err_proc_iid_sigma;
   vector[d] GPP_inst[n];
   vector[d] ER_inst[n];
   vector[d] KO2_inst[n];
   vector[d] DO_mod_partial[n];
+  
+  // Rescale pooling distribution parameter
+  K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -108,6 +113,7 @@ model {
   // Hierarchical constraints on K600_daily (linear model)
   lnK600_lnQ_intercept ~ normal(lnK600_lnQ_intercept_mu, lnK600_lnQ_intercept_sigma);
   lnK600_lnQ_slope ~ normal(lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma);
+  K600_daily_sigma_scaled ~ normal(0, 1);
   
 }
 generated quantities {

--- a/inst/models/b_Kl_pi_tr_plrckm.stan
+++ b/inst/models/b_Kl_pi_tr_plrckm.stan
@@ -14,7 +14,7 @@ data {
   real<lower=0> lnK600_lnQ_intercept_sigma;
   real lnK600_lnQ_slope_mu;
   real<lower=0> lnK600_lnQ_slope_sigma;
-  real<lower=0> K600_daily_sigma;
+  real<lower=0> K600_daily_sigma_sigma;
   
   // Error distributions
   real<lower=0> err_proc_iid_sigma_scale;
@@ -46,18 +46,23 @@ parameters {
   
   real lnK600_lnQ_intercept;
   real lnK600_lnQ_slope;
+  real<lower=0> K600_daily_sigma_scaled;
   
   real<lower=0> err_proc_iid_sigma_scaled;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
+  real<lower=0> K600_daily_sigma;
   vector[d] DO_mod_partial_sigma[n];
   real<lower=0> err_proc_iid_sigma;
   vector[d] GPP_inst[n];
   vector[d] ER_inst[n];
   vector[d] KO2_inst[n];
   vector[d] DO_mod_partial[n];
+  
+  // Rescale pooling distribution parameter
+  K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -113,6 +118,7 @@ model {
   // Hierarchical constraints on K600_daily (linear model)
   lnK600_lnQ_intercept ~ normal(lnK600_lnQ_intercept_mu, lnK600_lnQ_intercept_sigma);
   lnK600_lnQ_slope ~ normal(lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma);
+  K600_daily_sigma_scaled ~ normal(0, 1);
   
 }
 generated quantities {

--- a/inst/models/b_Kl_pi_tr_plrcko.stan
+++ b/inst/models/b_Kl_pi_tr_plrcko.stan
@@ -14,7 +14,7 @@ data {
   real<lower=0> lnK600_lnQ_intercept_sigma;
   real lnK600_lnQ_slope_mu;
   real<lower=0> lnK600_lnQ_slope_sigma;
-  real<lower=0> K600_daily_sigma;
+  real<lower=0> K600_daily_sigma_sigma;
   
   // Error distributions
   real<lower=0> err_proc_iid_sigma_scale;
@@ -46,18 +46,23 @@ parameters {
   
   real lnK600_lnQ_intercept;
   real lnK600_lnQ_slope;
+  real<lower=0> K600_daily_sigma_scaled;
   
   real<lower=0> err_proc_iid_sigma_scaled;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
+  real<lower=0> K600_daily_sigma;
   vector[d] DO_mod_partial_sigma[n];
   real<lower=0> err_proc_iid_sigma;
   vector[d] GPP_inst[n];
   vector[d] ER_inst[n];
   vector[d] KO2_inst[n];
   vector[d] DO_mod_partial[n];
+  
+  // Rescale pooling distribution parameter
+  K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -111,6 +116,7 @@ model {
   // Hierarchical constraints on K600_daily (linear model)
   lnK600_lnQ_intercept ~ normal(lnK600_lnQ_intercept_mu, lnK600_lnQ_intercept_sigma);
   lnK600_lnQ_slope ~ normal(lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma);
+  K600_daily_sigma_scaled ~ normal(0, 1);
   
 }
 generated quantities {

--- a/inst/models/b_Klx_oi_eu_plrckm.stan
+++ b/inst/models/b_Klx_oi_eu_plrckm.stan
@@ -1,0 +1,121 @@
+// b_Klx_oi_eu_plrckm.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (linear_sdfixed model)
+  real lnK600_lnQ_intercept_mu;
+  real<lower=0> lnK600_lnQ_intercept_sigma;
+  real lnK600_lnQ_slope_mu;
+  real<lower=0> lnK600_lnQ_slope_sigma;
+  real<lower=0> K600_daily_sigma;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  vector[d] lnQ_daily;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  vector<lower=0>[d] K600_daily;
+  
+  real lnK600_lnQ_intercept;
+  real lnK600_lnQ_slope;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  
+  // Hierarchical, linear_sdfixed model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_intercept + lnK600_lnQ_slope * lnQ_daily;
+  
+  // Model DO time series
+  // * euler version
+  // * observation error
+  // * no process error
+  // * reaeration depends on DO_mod
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  DO_mod[1] = DO_obs_1;
+  for(i in 1:(n-1)) {
+    DO_mod[i+1] =
+      DO_mod[i] + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        KO2_inst[i] .* (DO_sat[i] - DO_mod[i])
+      ) * timestep;
+  }
+}
+
+model {
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  K600_daily ~ normal(exp(K600_daily_predlog), K600_daily_sigma);
+  // Hierarchical constraints on K600_daily (linear_sdfixed model)
+  lnK600_lnQ_intercept ~ normal(lnK600_lnQ_intercept_mu, lnK600_lnQ_intercept_sigma);
+  lnK600_lnQ_slope ~ normal(lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma);
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Klx_oi_eu_plrcko.stan
+++ b/inst/models/b_Klx_oi_eu_plrcko.stan
@@ -1,0 +1,121 @@
+// b_Klx_oi_eu_plrcko.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (linear_sdfixed model)
+  real lnK600_lnQ_intercept_mu;
+  real<lower=0> lnK600_lnQ_intercept_sigma;
+  real lnK600_lnQ_slope_mu;
+  real<lower=0> lnK600_lnQ_slope_sigma;
+  real<lower=0> K600_daily_sigma;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  vector[d] lnQ_daily;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  vector<lower=0>[d] K600_daily;
+  
+  real lnK600_lnQ_intercept;
+  real lnK600_lnQ_slope;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  
+  // Hierarchical, linear_sdfixed model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_intercept + lnK600_lnQ_slope * lnQ_daily;
+  
+  // Model DO time series
+  // * euler version
+  // * observation error
+  // * no process error
+  // * reaeration depends on DO_obs
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  DO_mod[1] = DO_obs_1;
+  for(i in 1:(n-1)) {
+    DO_mod[i+1] =
+      DO_mod[i] + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        KO2_inst[i] .* (DO_sat[i] - DO_obs[i])
+      ) * timestep;
+  }
+}
+
+model {
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  K600_daily ~ normal(exp(K600_daily_predlog), K600_daily_sigma);
+  // Hierarchical constraints on K600_daily (linear_sdfixed model)
+  lnK600_lnQ_intercept ~ normal(lnK600_lnQ_intercept_mu, lnK600_lnQ_intercept_sigma);
+  lnK600_lnQ_slope ~ normal(lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma);
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Klx_oi_tr_plrckm.stan
+++ b/inst/models/b_Klx_oi_tr_plrckm.stan
@@ -1,0 +1,123 @@
+// b_Klx_oi_tr_plrckm.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (linear_sdfixed model)
+  real lnK600_lnQ_intercept_mu;
+  real<lower=0> lnK600_lnQ_intercept_sigma;
+  real lnK600_lnQ_slope_mu;
+  real<lower=0> lnK600_lnQ_slope_sigma;
+  real<lower=0> K600_daily_sigma;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  vector[d] lnQ_daily;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  vector<lower=0>[d] K600_daily;
+  
+  real lnK600_lnQ_intercept;
+  real lnK600_lnQ_slope;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  
+  // Hierarchical, linear_sdfixed model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_intercept + lnK600_lnQ_slope * lnQ_daily;
+  
+  // Model DO time series
+  // * trapezoid version
+  // * observation error
+  // * no process error
+  // * reaeration depends on DO_mod
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  DO_mod[1] = DO_obs_1;
+  for(i in 1:(n-1)) {
+    DO_mod[i+1] =
+      DO_mod[i] .*
+        (2.0 - KO2_inst[i] * timestep) ./ (2.0 + KO2_inst[i+1] * timestep) + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        (GPP_inst[i+1] + ER_inst[i+1]) ./ depth[i+1] +
+        KO2_inst[i] .* DO_sat[i] + KO2_inst[i+1] .* DO_sat[i+1]
+      ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
+  }
+}
+
+model {
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  K600_daily ~ normal(exp(K600_daily_predlog), K600_daily_sigma);
+  // Hierarchical constraints on K600_daily (linear_sdfixed model)
+  lnK600_lnQ_intercept ~ normal(lnK600_lnQ_intercept_mu, lnK600_lnQ_intercept_sigma);
+  lnK600_lnQ_slope ~ normal(lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma);
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Klx_oi_tr_plrcko.stan
+++ b/inst/models/b_Klx_oi_tr_plrcko.stan
@@ -1,0 +1,123 @@
+// b_Klx_oi_tr_plrcko.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (linear_sdfixed model)
+  real lnK600_lnQ_intercept_mu;
+  real<lower=0> lnK600_lnQ_intercept_sigma;
+  real lnK600_lnQ_slope_mu;
+  real<lower=0> lnK600_lnQ_slope_sigma;
+  real<lower=0> K600_daily_sigma;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  vector[d] lnQ_daily;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  vector<lower=0>[d] K600_daily;
+  
+  real lnK600_lnQ_intercept;
+  real lnK600_lnQ_slope;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  
+  // Hierarchical, linear_sdfixed model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_intercept + lnK600_lnQ_slope * lnQ_daily;
+  
+  // Model DO time series
+  // * trapezoid version
+  // * observation error
+  // * no process error
+  // * reaeration depends on DO_obs
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  DO_mod[1] = DO_obs_1;
+  for(i in 1:(n-1)) {
+    DO_mod[i+1] =
+      DO_mod[i] + (
+        - KO2_inst[i] .* DO_obs[i] - KO2_inst[i+1] .* DO_obs[i+1] +
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        (GPP_inst[i+1] + ER_inst[i+1]) ./ depth[i+1] +
+        KO2_inst[i] .* DO_sat[i] + KO2_inst[i+1] .* DO_sat[i+1]
+      ) * (timestep / 2.0);
+  }
+}
+
+model {
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  K600_daily ~ normal(exp(K600_daily_predlog), K600_daily_sigma);
+  // Hierarchical constraints on K600_daily (linear_sdfixed model)
+  lnK600_lnQ_intercept ~ normal(lnK600_lnQ_intercept_mu, lnK600_lnQ_intercept_sigma);
+  lnK600_lnQ_slope ~ normal(lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma);
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Klx_oipi_eu_plrckm.stan
+++ b/inst/models/b_Klx_oipi_eu_plrckm.stan
@@ -1,0 +1,140 @@
+// b_Klx_oipi_eu_plrckm.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (linear_sdfixed model)
+  real lnK600_lnQ_intercept_mu;
+  real<lower=0> lnK600_lnQ_intercept_sigma;
+  real lnK600_lnQ_slope_mu;
+  real<lower=0> lnK600_lnQ_slope_sigma;
+  real<lower=0> K600_daily_sigma;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  vector[d] lnQ_daily;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  vector<lower=0>[d] K600_daily;
+  
+  real lnK600_lnQ_intercept;
+  real lnK600_lnQ_slope;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+  real<lower=0> err_proc_iid_sigma_scaled;
+  vector[d] DO_mod[n];
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, linear_sdfixed model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_intercept + lnK600_lnQ_slope * lnQ_daily;
+  
+  // Model DO time series
+  // * euler version
+  // * observation error
+  // * IID process error
+  // * reaeration depends on DO_mod
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_mod[i] + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        KO2_inst[i] .* (DO_sat[i] - DO_mod[i])
+      ) * timestep;
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        timestep ./ depth[i,j];
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_mod[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  K600_daily ~ normal(exp(K600_daily_predlog), K600_daily_sigma);
+  // Hierarchical constraints on K600_daily (linear_sdfixed model)
+  lnK600_lnQ_intercept ~ normal(lnK600_lnQ_intercept_mu, lnK600_lnQ_intercept_sigma);
+  lnK600_lnQ_slope ~ normal(lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma);
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_mod[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Klx_oipi_eu_plrcko.stan
+++ b/inst/models/b_Klx_oipi_eu_plrcko.stan
@@ -1,0 +1,140 @@
+// b_Klx_oipi_eu_plrcko.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (linear_sdfixed model)
+  real lnK600_lnQ_intercept_mu;
+  real<lower=0> lnK600_lnQ_intercept_sigma;
+  real lnK600_lnQ_slope_mu;
+  real<lower=0> lnK600_lnQ_slope_sigma;
+  real<lower=0> K600_daily_sigma;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  vector[d] lnQ_daily;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  vector<lower=0>[d] K600_daily;
+  
+  real lnK600_lnQ_intercept;
+  real lnK600_lnQ_slope;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+  real<lower=0> err_proc_iid_sigma_scaled;
+  vector[d] DO_mod[n];
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, linear_sdfixed model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_intercept + lnK600_lnQ_slope * lnQ_daily;
+  
+  // Model DO time series
+  // * euler version
+  // * observation error
+  // * IID process error
+  // * reaeration depends on DO_obs
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_mod[i] + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        KO2_inst[i] .* (DO_sat[i] - DO_obs[i])
+      ) * timestep;
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        timestep ./ depth[i,j];
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_mod[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  K600_daily ~ normal(exp(K600_daily_predlog), K600_daily_sigma);
+  // Hierarchical constraints on K600_daily (linear_sdfixed model)
+  lnK600_lnQ_intercept ~ normal(lnK600_lnQ_intercept_mu, lnK600_lnQ_intercept_sigma);
+  lnK600_lnQ_slope ~ normal(lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma);
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_mod[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Klx_oipi_tr_plrckm.stan
+++ b/inst/models/b_Klx_oipi_tr_plrckm.stan
@@ -1,0 +1,143 @@
+// b_Klx_oipi_tr_plrckm.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (linear_sdfixed model)
+  real lnK600_lnQ_intercept_mu;
+  real<lower=0> lnK600_lnQ_intercept_sigma;
+  real lnK600_lnQ_slope_mu;
+  real<lower=0> lnK600_lnQ_slope_sigma;
+  real<lower=0> K600_daily_sigma;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  vector[d] lnQ_daily;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  vector<lower=0>[d] K600_daily;
+  
+  real lnK600_lnQ_intercept;
+  real lnK600_lnQ_slope;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+  real<lower=0> err_proc_iid_sigma_scaled;
+  vector[d] DO_mod[n];
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, linear_sdfixed model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_intercept + lnK600_lnQ_slope * lnQ_daily;
+  
+  // Model DO time series
+  // * trapezoid version
+  // * observation error
+  // * IID process error
+  // * reaeration depends on DO_mod
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_mod[i] .*
+        (2.0 - KO2_inst[i] * timestep) ./ (2.0 + KO2_inst[i+1] * timestep) + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        (GPP_inst[i+1] + ER_inst[i+1]) ./ depth[i+1] +
+        KO2_inst[i] .* DO_sat[i] + KO2_inst[i+1] .* DO_sat[i+1]
+      ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_mod[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  K600_daily ~ normal(exp(K600_daily_predlog), K600_daily_sigma);
+  // Hierarchical constraints on K600_daily (linear_sdfixed model)
+  lnK600_lnQ_intercept ~ normal(lnK600_lnQ_intercept_mu, lnK600_lnQ_intercept_sigma);
+  lnK600_lnQ_slope ~ normal(lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma);
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_mod[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Klx_oipi_tr_plrcko.stan
+++ b/inst/models/b_Klx_oipi_tr_plrcko.stan
@@ -1,0 +1,143 @@
+// b_Klx_oipi_tr_plrcko.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (linear_sdfixed model)
+  real lnK600_lnQ_intercept_mu;
+  real<lower=0> lnK600_lnQ_intercept_sigma;
+  real lnK600_lnQ_slope_mu;
+  real<lower=0> lnK600_lnQ_slope_sigma;
+  real<lower=0> K600_daily_sigma;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  vector[d] lnQ_daily;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  vector<lower=0>[d] K600_daily;
+  
+  real lnK600_lnQ_intercept;
+  real lnK600_lnQ_slope;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+  real<lower=0> err_proc_iid_sigma_scaled;
+  vector[d] DO_mod[n];
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, linear_sdfixed model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_intercept + lnK600_lnQ_slope * lnQ_daily;
+  
+  // Model DO time series
+  // * trapezoid version
+  // * observation error
+  // * IID process error
+  // * reaeration depends on DO_obs
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_mod[i] + (
+        - KO2_inst[i] .* DO_obs[i] - KO2_inst[i+1] .* DO_obs[i+1] +
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        (GPP_inst[i+1] + ER_inst[i+1]) ./ depth[i+1] +
+        KO2_inst[i] .* DO_sat[i] + KO2_inst[i+1] .* DO_sat[i+1]
+      ) * (timestep / 2.0);
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        (timestep / 2.0);
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_mod[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  K600_daily ~ normal(exp(K600_daily_predlog), K600_daily_sigma);
+  // Hierarchical constraints on K600_daily (linear_sdfixed model)
+  lnK600_lnQ_intercept ~ normal(lnK600_lnQ_intercept_mu, lnK600_lnQ_intercept_sigma);
+  lnK600_lnQ_slope ~ normal(lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma);
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_mod[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Klx_pi_eu_plrckm.stan
+++ b/inst/models/b_Klx_pi_eu_plrckm.stan
@@ -1,0 +1,128 @@
+// b_Klx_pi_eu_plrckm.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (linear_sdfixed model)
+  real lnK600_lnQ_intercept_mu;
+  real<lower=0> lnK600_lnQ_intercept_sigma;
+  real lnK600_lnQ_slope_mu;
+  real<lower=0> lnK600_lnQ_slope_sigma;
+  real<lower=0> K600_daily_sigma;
+  
+  // Error distributions
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  vector[d] lnQ_daily;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  vector<lower=0>[d] K600_daily;
+  
+  real lnK600_lnQ_intercept;
+  real lnK600_lnQ_slope;
+  
+  real<lower=0> err_proc_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, linear_sdfixed model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_intercept + lnK600_lnQ_slope * lnQ_daily;
+  
+  // Model DO time series
+  // * euler version
+  // * no observation error
+  // * IID process error
+  // * reaeration depends on DO_mod
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  DO_mod_partial[1] = DO_obs_1;
+  DO_mod_partial_sigma[1] = err_proc_iid_sigma * timestep ./ depth[1];
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_obs[i] + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        KO2_inst[i] .* (DO_sat[i] - DO_mod_partial[i])
+      ) * timestep;
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        timestep ./ depth[i,j];
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_obs[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  K600_daily ~ normal(exp(K600_daily_predlog), K600_daily_sigma);
+  // Hierarchical constraints on K600_daily (linear_sdfixed model)
+  lnK600_lnQ_intercept ~ normal(lnK600_lnQ_intercept_mu, lnK600_lnQ_intercept_sigma);
+  lnK600_lnQ_slope ~ normal(lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma);
+  
+}
+generated quantities {
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_obs[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Klx_pi_eu_plrcko.stan
+++ b/inst/models/b_Klx_pi_eu_plrcko.stan
@@ -1,0 +1,126 @@
+// b_Klx_pi_eu_plrcko.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (linear_sdfixed model)
+  real lnK600_lnQ_intercept_mu;
+  real<lower=0> lnK600_lnQ_intercept_sigma;
+  real lnK600_lnQ_slope_mu;
+  real<lower=0> lnK600_lnQ_slope_sigma;
+  real<lower=0> K600_daily_sigma;
+  
+  // Error distributions
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  vector[d] lnQ_daily;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  vector<lower=0>[d] K600_daily;
+  
+  real lnK600_lnQ_intercept;
+  real lnK600_lnQ_slope;
+  
+  real<lower=0> err_proc_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, linear_sdfixed model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_intercept + lnK600_lnQ_slope * lnQ_daily;
+  
+  // Model DO time series
+  // * euler version
+  // * no observation error
+  // * IID process error
+  // * reaeration depends on DO_obs
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_obs[i] + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        KO2_inst[i] .* (DO_sat[i] - DO_obs[i])
+      ) * timestep;
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        timestep ./ depth[i,j];
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_obs[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  K600_daily ~ normal(exp(K600_daily_predlog), K600_daily_sigma);
+  // Hierarchical constraints on K600_daily (linear_sdfixed model)
+  lnK600_lnQ_intercept ~ normal(lnK600_lnQ_intercept_mu, lnK600_lnQ_intercept_sigma);
+  lnK600_lnQ_slope ~ normal(lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma);
+  
+}
+generated quantities {
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_obs[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Klx_pi_tr_plrckm.stan
+++ b/inst/models/b_Klx_pi_tr_plrckm.stan
@@ -1,0 +1,131 @@
+// b_Klx_pi_tr_plrckm.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (linear_sdfixed model)
+  real lnK600_lnQ_intercept_mu;
+  real<lower=0> lnK600_lnQ_intercept_sigma;
+  real lnK600_lnQ_slope_mu;
+  real<lower=0> lnK600_lnQ_slope_sigma;
+  real<lower=0> K600_daily_sigma;
+  
+  // Error distributions
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  vector[d] lnQ_daily;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  vector<lower=0>[d] K600_daily;
+  
+  real lnK600_lnQ_intercept;
+  real lnK600_lnQ_slope;
+  
+  real<lower=0> err_proc_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, linear_sdfixed model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_intercept + lnK600_lnQ_slope * lnQ_daily;
+  
+  // Model DO time series
+  // * trapezoid version
+  // * no observation error
+  // * IID process error
+  // * reaeration depends on DO_mod
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  DO_mod_partial[1] = DO_obs_1;
+  DO_mod_partial_sigma[1] = err_proc_iid_sigma * timestep ./ depth[1];
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_mod_partial[i] .*
+        (2.0 - KO2_inst[i] * timestep) ./ (2.0 + KO2_inst[i+1] * timestep) + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        (GPP_inst[i+1] + ER_inst[i+1]) ./ depth[i+1] +
+        KO2_inst[i] .* DO_sat[i] + KO2_inst[i+1] .* DO_sat[i+1]
+      ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_obs[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  K600_daily ~ normal(exp(K600_daily_predlog), K600_daily_sigma);
+  // Hierarchical constraints on K600_daily (linear_sdfixed model)
+  lnK600_lnQ_intercept ~ normal(lnK600_lnQ_intercept_mu, lnK600_lnQ_intercept_sigma);
+  lnK600_lnQ_slope ~ normal(lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma);
+  
+}
+generated quantities {
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_obs[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Klx_pi_tr_plrcko.stan
+++ b/inst/models/b_Klx_pi_tr_plrcko.stan
@@ -1,0 +1,129 @@
+// b_Klx_pi_tr_plrcko.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (linear_sdfixed model)
+  real lnK600_lnQ_intercept_mu;
+  real<lower=0> lnK600_lnQ_intercept_sigma;
+  real lnK600_lnQ_slope_mu;
+  real<lower=0> lnK600_lnQ_slope_sigma;
+  real<lower=0> K600_daily_sigma;
+  
+  // Error distributions
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  vector[d] lnQ_daily;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  vector<lower=0>[d] K600_daily;
+  
+  real lnK600_lnQ_intercept;
+  real lnK600_lnQ_slope;
+  
+  real<lower=0> err_proc_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily_predlog;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, linear_sdfixed model of K600_daily
+  K600_daily_predlog = lnK600_lnQ_intercept + lnK600_lnQ_slope * lnQ_daily;
+  
+  // Model DO time series
+  // * trapezoid version
+  // * no observation error
+  // * IID process error
+  // * reaeration depends on DO_obs
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_obs[i] + (
+        - KO2_inst[i] .* DO_obs[i] - KO2_inst[i+1] .* DO_obs[i+1] +
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        (GPP_inst[i+1] + ER_inst[i+1]) ./ depth[i+1] +
+        KO2_inst[i] .* DO_sat[i] + KO2_inst[i+1] .* DO_sat[i+1]
+      ) * (timestep / 2.0);
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        (timestep / 2.0);
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_obs[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  K600_daily ~ normal(exp(K600_daily_predlog), K600_daily_sigma);
+  // Hierarchical constraints on K600_daily (linear_sdfixed model)
+  lnK600_lnQ_intercept ~ normal(lnK600_lnQ_intercept_mu, lnK600_lnQ_intercept_sigma);
+  lnK600_lnQ_slope ~ normal(lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma);
+  
+}
+generated quantities {
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_obs[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kn0_oi_eu_plrckm.stan
+++ b/inst/models/b_Kn0_oi_eu_plrckm.stan
@@ -1,0 +1,115 @@
+// b_Kn0_oi_eu_plrckm.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (normal_sdzero model)
+  real K600_daily_meanlog_meanlog;
+  real<lower=0> K600_daily_meanlog_sdlog;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  
+  real K600_daily_predlog;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  
+  // Hierarchical, normal_sdzero model of K600_daily
+  for(j in 1:d) {
+    K600_daily[j] = exp(K600_daily_predlog);
+  }
+  
+  // Model DO time series
+  // * euler version
+  // * observation error
+  // * no process error
+  // * reaeration depends on DO_mod
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  DO_mod[1] = DO_obs_1;
+  for(i in 1:(n-1)) {
+    DO_mod[i+1] =
+      DO_mod[i] + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        KO2_inst[i] .* (DO_sat[i] - DO_mod[i])
+      ) * timestep;
+  }
+}
+
+model {
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  // Hierarchical constraints on K600_daily (normal_sdzero model)
+  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog);
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kn0_oi_eu_plrcko.stan
+++ b/inst/models/b_Kn0_oi_eu_plrcko.stan
@@ -1,0 +1,115 @@
+// b_Kn0_oi_eu_plrcko.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (normal_sdzero model)
+  real K600_daily_meanlog_meanlog;
+  real<lower=0> K600_daily_meanlog_sdlog;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  
+  real K600_daily_predlog;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  
+  // Hierarchical, normal_sdzero model of K600_daily
+  for(j in 1:d) {
+    K600_daily[j] = exp(K600_daily_predlog);
+  }
+  
+  // Model DO time series
+  // * euler version
+  // * observation error
+  // * no process error
+  // * reaeration depends on DO_obs
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  DO_mod[1] = DO_obs_1;
+  for(i in 1:(n-1)) {
+    DO_mod[i+1] =
+      DO_mod[i] + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        KO2_inst[i] .* (DO_sat[i] - DO_obs[i])
+      ) * timestep;
+  }
+}
+
+model {
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  // Hierarchical constraints on K600_daily (normal_sdzero model)
+  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog);
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kn0_oi_tr_plrckm.stan
+++ b/inst/models/b_Kn0_oi_tr_plrckm.stan
@@ -1,0 +1,117 @@
+// b_Kn0_oi_tr_plrckm.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (normal_sdzero model)
+  real K600_daily_meanlog_meanlog;
+  real<lower=0> K600_daily_meanlog_sdlog;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  
+  real K600_daily_predlog;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  
+  // Hierarchical, normal_sdzero model of K600_daily
+  for(j in 1:d) {
+    K600_daily[j] = exp(K600_daily_predlog);
+  }
+  
+  // Model DO time series
+  // * trapezoid version
+  // * observation error
+  // * no process error
+  // * reaeration depends on DO_mod
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  DO_mod[1] = DO_obs_1;
+  for(i in 1:(n-1)) {
+    DO_mod[i+1] =
+      DO_mod[i] .*
+        (2.0 - KO2_inst[i] * timestep) ./ (2.0 + KO2_inst[i+1] * timestep) + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        (GPP_inst[i+1] + ER_inst[i+1]) ./ depth[i+1] +
+        KO2_inst[i] .* DO_sat[i] + KO2_inst[i+1] .* DO_sat[i+1]
+      ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
+  }
+}
+
+model {
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  // Hierarchical constraints on K600_daily (normal_sdzero model)
+  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog);
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kn0_oi_tr_plrcko.stan
+++ b/inst/models/b_Kn0_oi_tr_plrcko.stan
@@ -1,0 +1,117 @@
+// b_Kn0_oi_tr_plrcko.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (normal_sdzero model)
+  real K600_daily_meanlog_meanlog;
+  real<lower=0> K600_daily_meanlog_sdlog;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  
+  real K600_daily_predlog;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  
+  // Hierarchical, normal_sdzero model of K600_daily
+  for(j in 1:d) {
+    K600_daily[j] = exp(K600_daily_predlog);
+  }
+  
+  // Model DO time series
+  // * trapezoid version
+  // * observation error
+  // * no process error
+  // * reaeration depends on DO_obs
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  DO_mod[1] = DO_obs_1;
+  for(i in 1:(n-1)) {
+    DO_mod[i+1] =
+      DO_mod[i] + (
+        - KO2_inst[i] .* DO_obs[i] - KO2_inst[i+1] .* DO_obs[i+1] +
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        (GPP_inst[i+1] + ER_inst[i+1]) ./ depth[i+1] +
+        KO2_inst[i] .* DO_sat[i] + KO2_inst[i+1] .* DO_sat[i+1]
+      ) * (timestep / 2.0);
+  }
+}
+
+model {
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  // Hierarchical constraints on K600_daily (normal_sdzero model)
+  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog);
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kn0_oipi_eu_plrckm.stan
+++ b/inst/models/b_Kn0_oipi_eu_plrckm.stan
@@ -1,0 +1,134 @@
+// b_Kn0_oipi_eu_plrckm.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (normal_sdzero model)
+  real K600_daily_meanlog_meanlog;
+  real<lower=0> K600_daily_meanlog_sdlog;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  
+  real K600_daily_predlog;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+  real<lower=0> err_proc_iid_sigma_scaled;
+  vector[d] DO_mod[n];
+}
+
+transformed parameters {
+  vector[d] K600_daily;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, normal_sdzero model of K600_daily
+  for(j in 1:d) {
+    K600_daily[j] = exp(K600_daily_predlog);
+  }
+  
+  // Model DO time series
+  // * euler version
+  // * observation error
+  // * IID process error
+  // * reaeration depends on DO_mod
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_mod[i] + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        KO2_inst[i] .* (DO_sat[i] - DO_mod[i])
+      ) * timestep;
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        timestep ./ depth[i,j];
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_mod[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  // Hierarchical constraints on K600_daily (normal_sdzero model)
+  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog);
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_mod[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kn0_oipi_eu_plrcko.stan
+++ b/inst/models/b_Kn0_oipi_eu_plrcko.stan
@@ -1,0 +1,134 @@
+// b_Kn0_oipi_eu_plrcko.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (normal_sdzero model)
+  real K600_daily_meanlog_meanlog;
+  real<lower=0> K600_daily_meanlog_sdlog;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  
+  real K600_daily_predlog;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+  real<lower=0> err_proc_iid_sigma_scaled;
+  vector[d] DO_mod[n];
+}
+
+transformed parameters {
+  vector[d] K600_daily;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, normal_sdzero model of K600_daily
+  for(j in 1:d) {
+    K600_daily[j] = exp(K600_daily_predlog);
+  }
+  
+  // Model DO time series
+  // * euler version
+  // * observation error
+  // * IID process error
+  // * reaeration depends on DO_obs
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_mod[i] + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        KO2_inst[i] .* (DO_sat[i] - DO_obs[i])
+      ) * timestep;
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        timestep ./ depth[i,j];
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_mod[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  // Hierarchical constraints on K600_daily (normal_sdzero model)
+  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog);
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_mod[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kn0_oipi_tr_plrckm.stan
+++ b/inst/models/b_Kn0_oipi_tr_plrckm.stan
@@ -1,0 +1,137 @@
+// b_Kn0_oipi_tr_plrckm.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (normal_sdzero model)
+  real K600_daily_meanlog_meanlog;
+  real<lower=0> K600_daily_meanlog_sdlog;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  
+  real K600_daily_predlog;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+  real<lower=0> err_proc_iid_sigma_scaled;
+  vector[d] DO_mod[n];
+}
+
+transformed parameters {
+  vector[d] K600_daily;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, normal_sdzero model of K600_daily
+  for(j in 1:d) {
+    K600_daily[j] = exp(K600_daily_predlog);
+  }
+  
+  // Model DO time series
+  // * trapezoid version
+  // * observation error
+  // * IID process error
+  // * reaeration depends on DO_mod
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_mod[i] .*
+        (2.0 - KO2_inst[i] * timestep) ./ (2.0 + KO2_inst[i+1] * timestep) + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        (GPP_inst[i+1] + ER_inst[i+1]) ./ depth[i+1] +
+        KO2_inst[i] .* DO_sat[i] + KO2_inst[i+1] .* DO_sat[i+1]
+      ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_mod[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  // Hierarchical constraints on K600_daily (normal_sdzero model)
+  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog);
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_mod[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kn0_oipi_tr_plrcko.stan
+++ b/inst/models/b_Kn0_oipi_tr_plrcko.stan
@@ -1,0 +1,137 @@
+// b_Kn0_oipi_tr_plrcko.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (normal_sdzero model)
+  real K600_daily_meanlog_meanlog;
+  real<lower=0> K600_daily_meanlog_sdlog;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  
+  real K600_daily_predlog;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+  real<lower=0> err_proc_iid_sigma_scaled;
+  vector[d] DO_mod[n];
+}
+
+transformed parameters {
+  vector[d] K600_daily;
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, normal_sdzero model of K600_daily
+  for(j in 1:d) {
+    K600_daily[j] = exp(K600_daily_predlog);
+  }
+  
+  // Model DO time series
+  // * trapezoid version
+  // * observation error
+  // * IID process error
+  // * reaeration depends on DO_obs
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_mod[i] + (
+        - KO2_inst[i] .* DO_obs[i] - KO2_inst[i+1] .* DO_obs[i+1] +
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        (GPP_inst[i+1] + ER_inst[i+1]) ./ depth[i+1] +
+        KO2_inst[i] .* DO_sat[i] + KO2_inst[i+1] .* DO_sat[i+1]
+      ) * (timestep / 2.0);
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        (timestep / 2.0);
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_mod[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  // Hierarchical constraints on K600_daily (normal_sdzero model)
+  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog);
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_mod[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kn0_pi_eu_plrckm.stan
+++ b/inst/models/b_Kn0_pi_eu_plrckm.stan
@@ -1,0 +1,122 @@
+// b_Kn0_pi_eu_plrckm.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (normal_sdzero model)
+  real K600_daily_meanlog_meanlog;
+  real<lower=0> K600_daily_meanlog_sdlog;
+  
+  // Error distributions
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  
+  real K600_daily_predlog;
+  
+  real<lower=0> err_proc_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, normal_sdzero model of K600_daily
+  for(j in 1:d) {
+    K600_daily[j] = exp(K600_daily_predlog);
+  }
+  
+  // Model DO time series
+  // * euler version
+  // * no observation error
+  // * IID process error
+  // * reaeration depends on DO_mod
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  DO_mod_partial[1] = DO_obs_1;
+  DO_mod_partial_sigma[1] = err_proc_iid_sigma * timestep ./ depth[1];
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_obs[i] + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        KO2_inst[i] .* (DO_sat[i] - DO_mod_partial[i])
+      ) * timestep;
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        timestep ./ depth[i,j];
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_obs[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  // Hierarchical constraints on K600_daily (normal_sdzero model)
+  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog);
+  
+}
+generated quantities {
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_obs[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kn0_pi_eu_plrcko.stan
+++ b/inst/models/b_Kn0_pi_eu_plrcko.stan
@@ -1,0 +1,120 @@
+// b_Kn0_pi_eu_plrcko.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (normal_sdzero model)
+  real K600_daily_meanlog_meanlog;
+  real<lower=0> K600_daily_meanlog_sdlog;
+  
+  // Error distributions
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  
+  real K600_daily_predlog;
+  
+  real<lower=0> err_proc_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, normal_sdzero model of K600_daily
+  for(j in 1:d) {
+    K600_daily[j] = exp(K600_daily_predlog);
+  }
+  
+  // Model DO time series
+  // * euler version
+  // * no observation error
+  // * IID process error
+  // * reaeration depends on DO_obs
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_obs[i] + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        KO2_inst[i] .* (DO_sat[i] - DO_obs[i])
+      ) * timestep;
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        timestep ./ depth[i,j];
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_obs[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  // Hierarchical constraints on K600_daily (normal_sdzero model)
+  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog);
+  
+}
+generated quantities {
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_obs[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kn0_pi_tr_plrckm.stan
+++ b/inst/models/b_Kn0_pi_tr_plrckm.stan
@@ -1,0 +1,125 @@
+// b_Kn0_pi_tr_plrckm.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (normal_sdzero model)
+  real K600_daily_meanlog_meanlog;
+  real<lower=0> K600_daily_meanlog_sdlog;
+  
+  // Error distributions
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  
+  real K600_daily_predlog;
+  
+  real<lower=0> err_proc_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, normal_sdzero model of K600_daily
+  for(j in 1:d) {
+    K600_daily[j] = exp(K600_daily_predlog);
+  }
+  
+  // Model DO time series
+  // * trapezoid version
+  // * no observation error
+  // * IID process error
+  // * reaeration depends on DO_mod
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  DO_mod_partial[1] = DO_obs_1;
+  DO_mod_partial_sigma[1] = err_proc_iid_sigma * timestep ./ depth[1];
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_mod_partial[i] .*
+        (2.0 - KO2_inst[i] * timestep) ./ (2.0 + KO2_inst[i+1] * timestep) + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        (GPP_inst[i+1] + ER_inst[i+1]) ./ depth[i+1] +
+        KO2_inst[i] .* DO_sat[i] + KO2_inst[i+1] .* DO_sat[i+1]
+      ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_obs[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  // Hierarchical constraints on K600_daily (normal_sdzero model)
+  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog);
+  
+}
+generated quantities {
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_obs[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kn0_pi_tr_plrcko.stan
+++ b/inst/models/b_Kn0_pi_tr_plrcko.stan
@@ -1,0 +1,123 @@
+// b_Kn0_pi_tr_plrcko.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (normal_sdzero model)
+  real K600_daily_meanlog_meanlog;
+  real<lower=0> K600_daily_meanlog_sdlog;
+  
+  // Error distributions
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  
+  real K600_daily_predlog;
+  
+  real<lower=0> err_proc_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] K600_daily;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Hierarchical, normal_sdzero model of K600_daily
+  for(j in 1:d) {
+    K600_daily[j] = exp(K600_daily_predlog);
+  }
+  
+  // Model DO time series
+  // * trapezoid version
+  // * no observation error
+  // * IID process error
+  // * reaeration depends on DO_obs
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_obs[i] + (
+        - KO2_inst[i] .* DO_obs[i] - KO2_inst[i+1] .* DO_obs[i+1] +
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        (GPP_inst[i+1] + ER_inst[i+1]) ./ depth[i+1] +
+        KO2_inst[i] .* DO_sat[i] + KO2_inst[i+1] .* DO_sat[i+1]
+      ) * (timestep / 2.0);
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        (timestep / 2.0);
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_obs[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  // Hierarchical constraints on K600_daily (normal_sdzero model)
+  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog);
+  
+}
+generated quantities {
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_obs[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Kn_oi_eu_plrckm.stan
+++ b/inst/models/b_Kn_oi_eu_plrckm.stan
@@ -12,7 +12,7 @@ data {
   // Parameters of hierarchical priors on K600_daily (normal model)
   real K600_daily_meanlog_meanlog;
   real<lower=0> K600_daily_meanlog_sdlog;
-  real<lower=0> K600_daily_sdlog;
+  real<lower=0> K600_daily_sdlog_sigma;
   
   // Error distributions
   real<lower=0> err_obs_iid_sigma_scale;
@@ -42,16 +42,21 @@ parameters {
   vector<lower=0>[d] K600_daily;
   
   real K600_daily_predlog;
+  real<lower=0> K600_daily_sdlog_scaled;
   
   real<lower=0> err_obs_iid_sigma_scaled;
 }
 
 transformed parameters {
+  real<lower=0> K600_daily_sdlog;
   real<lower=0> err_obs_iid_sigma;
   vector[d] GPP_inst[n];
   vector[d] ER_inst[n];
   vector[d] KO2_inst[n];
   vector[d] DO_mod[n];
+  
+  // Rescale pooling distribution parameter
+  K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -93,7 +98,8 @@ model {
   ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
   K600_daily ~ lognormal(K600_daily_predlog, K600_daily_sdlog);
   // Hierarchical constraints on K600_daily (normal model)
-  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog );
+  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog);
+  K600_daily_sdlog_scaled ~ normal(0, 1);
   
 }
 generated quantities {

--- a/inst/models/b_Kn_oi_eu_plrcko.stan
+++ b/inst/models/b_Kn_oi_eu_plrcko.stan
@@ -12,7 +12,7 @@ data {
   // Parameters of hierarchical priors on K600_daily (normal model)
   real K600_daily_meanlog_meanlog;
   real<lower=0> K600_daily_meanlog_sdlog;
-  real<lower=0> K600_daily_sdlog;
+  real<lower=0> K600_daily_sdlog_sigma;
   
   // Error distributions
   real<lower=0> err_obs_iid_sigma_scale;
@@ -42,16 +42,21 @@ parameters {
   vector<lower=0>[d] K600_daily;
   
   real K600_daily_predlog;
+  real<lower=0> K600_daily_sdlog_scaled;
   
   real<lower=0> err_obs_iid_sigma_scaled;
 }
 
 transformed parameters {
+  real<lower=0> K600_daily_sdlog;
   real<lower=0> err_obs_iid_sigma;
   vector[d] GPP_inst[n];
   vector[d] ER_inst[n];
   vector[d] KO2_inst[n];
   vector[d] DO_mod[n];
+  
+  // Rescale pooling distribution parameter
+  K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -93,7 +98,8 @@ model {
   ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
   K600_daily ~ lognormal(K600_daily_predlog, K600_daily_sdlog);
   // Hierarchical constraints on K600_daily (normal model)
-  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog );
+  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog);
+  K600_daily_sdlog_scaled ~ normal(0, 1);
   
 }
 generated quantities {

--- a/inst/models/b_Kn_oi_tr_plrckm.stan
+++ b/inst/models/b_Kn_oi_tr_plrckm.stan
@@ -12,7 +12,7 @@ data {
   // Parameters of hierarchical priors on K600_daily (normal model)
   real K600_daily_meanlog_meanlog;
   real<lower=0> K600_daily_meanlog_sdlog;
-  real<lower=0> K600_daily_sdlog;
+  real<lower=0> K600_daily_sdlog_sigma;
   
   // Error distributions
   real<lower=0> err_obs_iid_sigma_scale;
@@ -42,16 +42,21 @@ parameters {
   vector<lower=0>[d] K600_daily;
   
   real K600_daily_predlog;
+  real<lower=0> K600_daily_sdlog_scaled;
   
   real<lower=0> err_obs_iid_sigma_scaled;
 }
 
 transformed parameters {
+  real<lower=0> K600_daily_sdlog;
   real<lower=0> err_obs_iid_sigma;
   vector[d] GPP_inst[n];
   vector[d] ER_inst[n];
   vector[d] KO2_inst[n];
   vector[d] DO_mod[n];
+  
+  // Rescale pooling distribution parameter
+  K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -95,7 +100,8 @@ model {
   ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
   K600_daily ~ lognormal(K600_daily_predlog, K600_daily_sdlog);
   // Hierarchical constraints on K600_daily (normal model)
-  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog );
+  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog);
+  K600_daily_sdlog_scaled ~ normal(0, 1);
   
 }
 generated quantities {

--- a/inst/models/b_Kn_oi_tr_plrcko.stan
+++ b/inst/models/b_Kn_oi_tr_plrcko.stan
@@ -12,7 +12,7 @@ data {
   // Parameters of hierarchical priors on K600_daily (normal model)
   real K600_daily_meanlog_meanlog;
   real<lower=0> K600_daily_meanlog_sdlog;
-  real<lower=0> K600_daily_sdlog;
+  real<lower=0> K600_daily_sdlog_sigma;
   
   // Error distributions
   real<lower=0> err_obs_iid_sigma_scale;
@@ -42,16 +42,21 @@ parameters {
   vector<lower=0>[d] K600_daily;
   
   real K600_daily_predlog;
+  real<lower=0> K600_daily_sdlog_scaled;
   
   real<lower=0> err_obs_iid_sigma_scaled;
 }
 
 transformed parameters {
+  real<lower=0> K600_daily_sdlog;
   real<lower=0> err_obs_iid_sigma;
   vector[d] GPP_inst[n];
   vector[d] ER_inst[n];
   vector[d] KO2_inst[n];
   vector[d] DO_mod[n];
+  
+  // Rescale pooling distribution parameter
+  K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -95,7 +100,8 @@ model {
   ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
   K600_daily ~ lognormal(K600_daily_predlog, K600_daily_sdlog);
   // Hierarchical constraints on K600_daily (normal model)
-  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog );
+  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog);
+  K600_daily_sdlog_scaled ~ normal(0, 1);
   
 }
 generated quantities {

--- a/inst/models/b_Kn_oipi_eu_plrckm.stan
+++ b/inst/models/b_Kn_oipi_eu_plrckm.stan
@@ -12,7 +12,7 @@ data {
   // Parameters of hierarchical priors on K600_daily (normal model)
   real K600_daily_meanlog_meanlog;
   real<lower=0> K600_daily_meanlog_sdlog;
-  real<lower=0> K600_daily_sdlog;
+  real<lower=0> K600_daily_sdlog_sigma;
   
   // Error distributions
   real<lower=0> err_obs_iid_sigma_scale;
@@ -43,6 +43,7 @@ parameters {
   vector<lower=0>[d] K600_daily;
   
   real K600_daily_predlog;
+  real<lower=0> K600_daily_sdlog_scaled;
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
@@ -50,6 +51,7 @@ parameters {
 }
 
 transformed parameters {
+  real<lower=0> K600_daily_sdlog;
   real<lower=0> err_obs_iid_sigma;
   vector[d] DO_mod_partial_sigma[n];
   real<lower=0> err_proc_iid_sigma;
@@ -57,6 +59,9 @@ transformed parameters {
   vector[d] ER_inst[n];
   vector[d] KO2_inst[n];
   vector[d] DO_mod_partial[n];
+  
+  // Rescale pooling distribution parameter
+  K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -110,7 +115,8 @@ model {
   ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
   K600_daily ~ lognormal(K600_daily_predlog, K600_daily_sdlog);
   // Hierarchical constraints on K600_daily (normal model)
-  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog );
+  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog);
+  K600_daily_sdlog_scaled ~ normal(0, 1);
   
 }
 generated quantities {

--- a/inst/models/b_Kn_oipi_eu_plrcko.stan
+++ b/inst/models/b_Kn_oipi_eu_plrcko.stan
@@ -12,7 +12,7 @@ data {
   // Parameters of hierarchical priors on K600_daily (normal model)
   real K600_daily_meanlog_meanlog;
   real<lower=0> K600_daily_meanlog_sdlog;
-  real<lower=0> K600_daily_sdlog;
+  real<lower=0> K600_daily_sdlog_sigma;
   
   // Error distributions
   real<lower=0> err_obs_iid_sigma_scale;
@@ -43,6 +43,7 @@ parameters {
   vector<lower=0>[d] K600_daily;
   
   real K600_daily_predlog;
+  real<lower=0> K600_daily_sdlog_scaled;
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
@@ -50,6 +51,7 @@ parameters {
 }
 
 transformed parameters {
+  real<lower=0> K600_daily_sdlog;
   real<lower=0> err_obs_iid_sigma;
   vector[d] DO_mod_partial_sigma[n];
   real<lower=0> err_proc_iid_sigma;
@@ -57,6 +59,9 @@ transformed parameters {
   vector[d] ER_inst[n];
   vector[d] KO2_inst[n];
   vector[d] DO_mod_partial[n];
+  
+  // Rescale pooling distribution parameter
+  K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -110,7 +115,8 @@ model {
   ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
   K600_daily ~ lognormal(K600_daily_predlog, K600_daily_sdlog);
   // Hierarchical constraints on K600_daily (normal model)
-  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog );
+  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog);
+  K600_daily_sdlog_scaled ~ normal(0, 1);
   
 }
 generated quantities {

--- a/inst/models/b_Kn_oipi_tr_plrckm.stan
+++ b/inst/models/b_Kn_oipi_tr_plrckm.stan
@@ -12,7 +12,7 @@ data {
   // Parameters of hierarchical priors on K600_daily (normal model)
   real K600_daily_meanlog_meanlog;
   real<lower=0> K600_daily_meanlog_sdlog;
-  real<lower=0> K600_daily_sdlog;
+  real<lower=0> K600_daily_sdlog_sigma;
   
   // Error distributions
   real<lower=0> err_obs_iid_sigma_scale;
@@ -43,6 +43,7 @@ parameters {
   vector<lower=0>[d] K600_daily;
   
   real K600_daily_predlog;
+  real<lower=0> K600_daily_sdlog_scaled;
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
@@ -50,6 +51,7 @@ parameters {
 }
 
 transformed parameters {
+  real<lower=0> K600_daily_sdlog;
   real<lower=0> err_obs_iid_sigma;
   vector[d] DO_mod_partial_sigma[n];
   real<lower=0> err_proc_iid_sigma;
@@ -57,6 +59,9 @@ transformed parameters {
   vector[d] ER_inst[n];
   vector[d] KO2_inst[n];
   vector[d] DO_mod_partial[n];
+  
+  // Rescale pooling distribution parameter
+  K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -113,7 +118,8 @@ model {
   ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
   K600_daily ~ lognormal(K600_daily_predlog, K600_daily_sdlog);
   // Hierarchical constraints on K600_daily (normal model)
-  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog );
+  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog);
+  K600_daily_sdlog_scaled ~ normal(0, 1);
   
 }
 generated quantities {

--- a/inst/models/b_Kn_oipi_tr_plrcko.stan
+++ b/inst/models/b_Kn_oipi_tr_plrcko.stan
@@ -12,7 +12,7 @@ data {
   // Parameters of hierarchical priors on K600_daily (normal model)
   real K600_daily_meanlog_meanlog;
   real<lower=0> K600_daily_meanlog_sdlog;
-  real<lower=0> K600_daily_sdlog;
+  real<lower=0> K600_daily_sdlog_sigma;
   
   // Error distributions
   real<lower=0> err_obs_iid_sigma_scale;
@@ -43,6 +43,7 @@ parameters {
   vector<lower=0>[d] K600_daily;
   
   real K600_daily_predlog;
+  real<lower=0> K600_daily_sdlog_scaled;
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
@@ -50,6 +51,7 @@ parameters {
 }
 
 transformed parameters {
+  real<lower=0> K600_daily_sdlog;
   real<lower=0> err_obs_iid_sigma;
   vector[d] DO_mod_partial_sigma[n];
   real<lower=0> err_proc_iid_sigma;
@@ -57,6 +59,9 @@ transformed parameters {
   vector[d] ER_inst[n];
   vector[d] KO2_inst[n];
   vector[d] DO_mod_partial[n];
+  
+  // Rescale pooling distribution parameter
+  K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -113,7 +118,8 @@ model {
   ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
   K600_daily ~ lognormal(K600_daily_predlog, K600_daily_sdlog);
   // Hierarchical constraints on K600_daily (normal model)
-  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog );
+  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog);
+  K600_daily_sdlog_scaled ~ normal(0, 1);
   
 }
 generated quantities {

--- a/inst/models/b_Kn_pi_eu_plrckm.stan
+++ b/inst/models/b_Kn_pi_eu_plrckm.stan
@@ -12,7 +12,7 @@ data {
   // Parameters of hierarchical priors on K600_daily (normal model)
   real K600_daily_meanlog_meanlog;
   real<lower=0> K600_daily_meanlog_sdlog;
-  real<lower=0> K600_daily_sdlog;
+  real<lower=0> K600_daily_sdlog_sigma;
   
   // Error distributions
   real<lower=0> err_proc_iid_sigma_scale;
@@ -42,17 +42,22 @@ parameters {
   vector<lower=0>[d] K600_daily;
   
   real K600_daily_predlog;
+  real<lower=0> K600_daily_sdlog_scaled;
   
   real<lower=0> err_proc_iid_sigma_scaled;
 }
 
 transformed parameters {
+  real<lower=0> K600_daily_sdlog;
   vector[d] DO_mod_partial_sigma[n];
   real<lower=0> err_proc_iid_sigma;
   vector[d] GPP_inst[n];
   vector[d] ER_inst[n];
   vector[d] KO2_inst[n];
   vector[d] DO_mod_partial[n];
+  
+  // Rescale pooling distribution parameter
+  K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -100,7 +105,8 @@ model {
   ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
   K600_daily ~ lognormal(K600_daily_predlog, K600_daily_sdlog);
   // Hierarchical constraints on K600_daily (normal model)
-  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog );
+  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog);
+  K600_daily_sdlog_scaled ~ normal(0, 1);
   
 }
 generated quantities {

--- a/inst/models/b_Kn_pi_eu_plrcko.stan
+++ b/inst/models/b_Kn_pi_eu_plrcko.stan
@@ -12,7 +12,7 @@ data {
   // Parameters of hierarchical priors on K600_daily (normal model)
   real K600_daily_meanlog_meanlog;
   real<lower=0> K600_daily_meanlog_sdlog;
-  real<lower=0> K600_daily_sdlog;
+  real<lower=0> K600_daily_sdlog_sigma;
   
   // Error distributions
   real<lower=0> err_proc_iid_sigma_scale;
@@ -42,17 +42,22 @@ parameters {
   vector<lower=0>[d] K600_daily;
   
   real K600_daily_predlog;
+  real<lower=0> K600_daily_sdlog_scaled;
   
   real<lower=0> err_proc_iid_sigma_scaled;
 }
 
 transformed parameters {
+  real<lower=0> K600_daily_sdlog;
   vector[d] DO_mod_partial_sigma[n];
   real<lower=0> err_proc_iid_sigma;
   vector[d] GPP_inst[n];
   vector[d] ER_inst[n];
   vector[d] KO2_inst[n];
   vector[d] DO_mod_partial[n];
+  
+  // Rescale pooling distribution parameter
+  K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -98,7 +103,8 @@ model {
   ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
   K600_daily ~ lognormal(K600_daily_predlog, K600_daily_sdlog);
   // Hierarchical constraints on K600_daily (normal model)
-  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog );
+  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog);
+  K600_daily_sdlog_scaled ~ normal(0, 1);
   
 }
 generated quantities {

--- a/inst/models/b_Kn_pi_tr_plrckm.stan
+++ b/inst/models/b_Kn_pi_tr_plrckm.stan
@@ -12,7 +12,7 @@ data {
   // Parameters of hierarchical priors on K600_daily (normal model)
   real K600_daily_meanlog_meanlog;
   real<lower=0> K600_daily_meanlog_sdlog;
-  real<lower=0> K600_daily_sdlog;
+  real<lower=0> K600_daily_sdlog_sigma;
   
   // Error distributions
   real<lower=0> err_proc_iid_sigma_scale;
@@ -42,17 +42,22 @@ parameters {
   vector<lower=0>[d] K600_daily;
   
   real K600_daily_predlog;
+  real<lower=0> K600_daily_sdlog_scaled;
   
   real<lower=0> err_proc_iid_sigma_scaled;
 }
 
 transformed parameters {
+  real<lower=0> K600_daily_sdlog;
   vector[d] DO_mod_partial_sigma[n];
   real<lower=0> err_proc_iid_sigma;
   vector[d] GPP_inst[n];
   vector[d] ER_inst[n];
   vector[d] KO2_inst[n];
   vector[d] DO_mod_partial[n];
+  
+  // Rescale pooling distribution parameter
+  K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -103,7 +108,8 @@ model {
   ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
   K600_daily ~ lognormal(K600_daily_predlog, K600_daily_sdlog);
   // Hierarchical constraints on K600_daily (normal model)
-  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog );
+  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog);
+  K600_daily_sdlog_scaled ~ normal(0, 1);
   
 }
 generated quantities {

--- a/inst/models/b_Kn_pi_tr_plrcko.stan
+++ b/inst/models/b_Kn_pi_tr_plrcko.stan
@@ -12,7 +12,7 @@ data {
   // Parameters of hierarchical priors on K600_daily (normal model)
   real K600_daily_meanlog_meanlog;
   real<lower=0> K600_daily_meanlog_sdlog;
-  real<lower=0> K600_daily_sdlog;
+  real<lower=0> K600_daily_sdlog_sigma;
   
   // Error distributions
   real<lower=0> err_proc_iid_sigma_scale;
@@ -42,17 +42,22 @@ parameters {
   vector<lower=0>[d] K600_daily;
   
   real K600_daily_predlog;
+  real<lower=0> K600_daily_sdlog_scaled;
   
   real<lower=0> err_proc_iid_sigma_scaled;
 }
 
 transformed parameters {
+  real<lower=0> K600_daily_sdlog;
   vector[d] DO_mod_partial_sigma[n];
   real<lower=0> err_proc_iid_sigma;
   vector[d] GPP_inst[n];
   vector[d] ER_inst[n];
   vector[d] KO2_inst[n];
   vector[d] DO_mod_partial[n];
+  
+  // Rescale pooling distribution parameter
+  K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -101,7 +106,8 @@ model {
   ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
   K600_daily ~ lognormal(K600_daily_predlog, K600_daily_sdlog);
   // Hierarchical constraints on K600_daily (normal model)
-  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog );
+  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog);
+  K600_daily_sdlog_scaled ~ normal(0, 1);
   
 }
 generated quantities {

--- a/inst/models/b_Knx_oi_eu_plrckm.stan
+++ b/inst/models/b_Knx_oi_eu_plrckm.stan
@@ -1,0 +1,112 @@
+// b_Knx_oi_eu_plrckm.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (normal_sdfixed model)
+  real K600_daily_meanlog_meanlog;
+  real<lower=0> K600_daily_meanlog_sdlog;
+  real<lower=0> K600_daily_sdlog;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  vector<lower=0>[d] K600_daily;
+  
+  real K600_daily_predlog;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+}
+
+transformed parameters {
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  
+  // Model DO time series
+  // * euler version
+  // * observation error
+  // * no process error
+  // * reaeration depends on DO_mod
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  DO_mod[1] = DO_obs_1;
+  for(i in 1:(n-1)) {
+    DO_mod[i+1] =
+      DO_mod[i] + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        KO2_inst[i] .* (DO_sat[i] - DO_mod[i])
+      ) * timestep;
+  }
+}
+
+model {
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  K600_daily ~ lognormal(K600_daily_predlog, K600_daily_sdlog);
+  // Hierarchical constraints on K600_daily (normal_sdfixed model)
+  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog);
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Knx_oi_eu_plrcko.stan
+++ b/inst/models/b_Knx_oi_eu_plrcko.stan
@@ -1,0 +1,112 @@
+// b_Knx_oi_eu_plrcko.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (normal_sdfixed model)
+  real K600_daily_meanlog_meanlog;
+  real<lower=0> K600_daily_meanlog_sdlog;
+  real<lower=0> K600_daily_sdlog;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  vector<lower=0>[d] K600_daily;
+  
+  real K600_daily_predlog;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+}
+
+transformed parameters {
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  
+  // Model DO time series
+  // * euler version
+  // * observation error
+  // * no process error
+  // * reaeration depends on DO_obs
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  DO_mod[1] = DO_obs_1;
+  for(i in 1:(n-1)) {
+    DO_mod[i+1] =
+      DO_mod[i] + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        KO2_inst[i] .* (DO_sat[i] - DO_obs[i])
+      ) * timestep;
+  }
+}
+
+model {
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  K600_daily ~ lognormal(K600_daily_predlog, K600_daily_sdlog);
+  // Hierarchical constraints on K600_daily (normal_sdfixed model)
+  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog);
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Knx_oi_tr_plrckm.stan
+++ b/inst/models/b_Knx_oi_tr_plrckm.stan
@@ -1,0 +1,114 @@
+// b_Knx_oi_tr_plrckm.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (normal_sdfixed model)
+  real K600_daily_meanlog_meanlog;
+  real<lower=0> K600_daily_meanlog_sdlog;
+  real<lower=0> K600_daily_sdlog;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  vector<lower=0>[d] K600_daily;
+  
+  real K600_daily_predlog;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+}
+
+transformed parameters {
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  
+  // Model DO time series
+  // * trapezoid version
+  // * observation error
+  // * no process error
+  // * reaeration depends on DO_mod
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  DO_mod[1] = DO_obs_1;
+  for(i in 1:(n-1)) {
+    DO_mod[i+1] =
+      DO_mod[i] .*
+        (2.0 - KO2_inst[i] * timestep) ./ (2.0 + KO2_inst[i+1] * timestep) + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        (GPP_inst[i+1] + ER_inst[i+1]) ./ depth[i+1] +
+        KO2_inst[i] .* DO_sat[i] + KO2_inst[i+1] .* DO_sat[i+1]
+      ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
+  }
+}
+
+model {
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  K600_daily ~ lognormal(K600_daily_predlog, K600_daily_sdlog);
+  // Hierarchical constraints on K600_daily (normal_sdfixed model)
+  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog);
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Knx_oi_tr_plrcko.stan
+++ b/inst/models/b_Knx_oi_tr_plrcko.stan
@@ -1,0 +1,114 @@
+// b_Knx_oi_tr_plrcko.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (normal_sdfixed model)
+  real K600_daily_meanlog_meanlog;
+  real<lower=0> K600_daily_meanlog_sdlog;
+  real<lower=0> K600_daily_sdlog;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  vector<lower=0>[d] K600_daily;
+  
+  real K600_daily_predlog;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+}
+
+transformed parameters {
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  
+  // Model DO time series
+  // * trapezoid version
+  // * observation error
+  // * no process error
+  // * reaeration depends on DO_obs
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  DO_mod[1] = DO_obs_1;
+  for(i in 1:(n-1)) {
+    DO_mod[i+1] =
+      DO_mod[i] + (
+        - KO2_inst[i] .* DO_obs[i] - KO2_inst[i+1] .* DO_obs[i+1] +
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        (GPP_inst[i+1] + ER_inst[i+1]) ./ depth[i+1] +
+        KO2_inst[i] .* DO_sat[i] + KO2_inst[i+1] .* DO_sat[i+1]
+      ) * (timestep / 2.0);
+  }
+}
+
+model {
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  K600_daily ~ lognormal(K600_daily_predlog, K600_daily_sdlog);
+  // Hierarchical constraints on K600_daily (normal_sdfixed model)
+  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog);
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Knx_oipi_eu_plrckm.stan
+++ b/inst/models/b_Knx_oipi_eu_plrckm.stan
@@ -1,0 +1,131 @@
+// b_Knx_oipi_eu_plrckm.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (normal_sdfixed model)
+  real K600_daily_meanlog_meanlog;
+  real<lower=0> K600_daily_meanlog_sdlog;
+  real<lower=0> K600_daily_sdlog;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  vector<lower=0>[d] K600_daily;
+  
+  real K600_daily_predlog;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+  real<lower=0> err_proc_iid_sigma_scaled;
+  vector[d] DO_mod[n];
+}
+
+transformed parameters {
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Model DO time series
+  // * euler version
+  // * observation error
+  // * IID process error
+  // * reaeration depends on DO_mod
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_mod[i] + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        KO2_inst[i] .* (DO_sat[i] - DO_mod[i])
+      ) * timestep;
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        timestep ./ depth[i,j];
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_mod[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  K600_daily ~ lognormal(K600_daily_predlog, K600_daily_sdlog);
+  // Hierarchical constraints on K600_daily (normal_sdfixed model)
+  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog);
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_mod[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Knx_oipi_eu_plrcko.stan
+++ b/inst/models/b_Knx_oipi_eu_plrcko.stan
@@ -1,0 +1,131 @@
+// b_Knx_oipi_eu_plrcko.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (normal_sdfixed model)
+  real K600_daily_meanlog_meanlog;
+  real<lower=0> K600_daily_meanlog_sdlog;
+  real<lower=0> K600_daily_sdlog;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  vector<lower=0>[d] K600_daily;
+  
+  real K600_daily_predlog;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+  real<lower=0> err_proc_iid_sigma_scaled;
+  vector[d] DO_mod[n];
+}
+
+transformed parameters {
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Model DO time series
+  // * euler version
+  // * observation error
+  // * IID process error
+  // * reaeration depends on DO_obs
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_mod[i] + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        KO2_inst[i] .* (DO_sat[i] - DO_obs[i])
+      ) * timestep;
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        timestep ./ depth[i,j];
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_mod[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  K600_daily ~ lognormal(K600_daily_predlog, K600_daily_sdlog);
+  // Hierarchical constraints on K600_daily (normal_sdfixed model)
+  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog);
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_mod[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Knx_oipi_tr_plrckm.stan
+++ b/inst/models/b_Knx_oipi_tr_plrckm.stan
@@ -1,0 +1,134 @@
+// b_Knx_oipi_tr_plrckm.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (normal_sdfixed model)
+  real K600_daily_meanlog_meanlog;
+  real<lower=0> K600_daily_meanlog_sdlog;
+  real<lower=0> K600_daily_sdlog;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  vector<lower=0>[d] K600_daily;
+  
+  real K600_daily_predlog;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+  real<lower=0> err_proc_iid_sigma_scaled;
+  vector[d] DO_mod[n];
+}
+
+transformed parameters {
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Model DO time series
+  // * trapezoid version
+  // * observation error
+  // * IID process error
+  // * reaeration depends on DO_mod
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_mod[i] .*
+        (2.0 - KO2_inst[i] * timestep) ./ (2.0 + KO2_inst[i+1] * timestep) + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        (GPP_inst[i+1] + ER_inst[i+1]) ./ depth[i+1] +
+        KO2_inst[i] .* DO_sat[i] + KO2_inst[i+1] .* DO_sat[i+1]
+      ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_mod[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  K600_daily ~ lognormal(K600_daily_predlog, K600_daily_sdlog);
+  // Hierarchical constraints on K600_daily (normal_sdfixed model)
+  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog);
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_mod[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Knx_oipi_tr_plrcko.stan
+++ b/inst/models/b_Knx_oipi_tr_plrcko.stan
@@ -1,0 +1,134 @@
+// b_Knx_oipi_tr_plrcko.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (normal_sdfixed model)
+  real K600_daily_meanlog_meanlog;
+  real<lower=0> K600_daily_meanlog_sdlog;
+  real<lower=0> K600_daily_sdlog;
+  
+  // Error distributions
+  real<lower=0> err_obs_iid_sigma_scale;
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  vector<lower=0>[d] K600_daily;
+  
+  real K600_daily_predlog;
+  
+  real<lower=0> err_obs_iid_sigma_scaled;
+  real<lower=0> err_proc_iid_sigma_scaled;
+  vector[d] DO_mod[n];
+}
+
+transformed parameters {
+  real<lower=0> err_obs_iid_sigma;
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Model DO time series
+  // * trapezoid version
+  // * observation error
+  // * IID process error
+  // * reaeration depends on DO_obs
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_mod[i] + (
+        - KO2_inst[i] .* DO_obs[i] - KO2_inst[i+1] .* DO_obs[i+1] +
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        (GPP_inst[i+1] + ER_inst[i+1]) ./ depth[i+1] +
+        KO2_inst[i] .* DO_sat[i] + KO2_inst[i+1] .* DO_sat[i+1]
+      ) * (timestep / 2.0);
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        (timestep / 2.0);
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_mod[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Independent, identically distributed observation error
+  for(i in 2:n) {
+    DO_obs[i] ~ normal(DO_mod[i], err_obs_iid_sigma);
+  }
+  // SD (sigma) of the observation errors
+  err_obs_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  K600_daily ~ lognormal(K600_daily_predlog, K600_daily_sdlog);
+  // Hierarchical constraints on K600_daily (normal_sdfixed model)
+  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog);
+  
+}
+generated quantities {
+  vector[d] err_obs_iid[n-1];
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_obs_iid[i] = DO_mod[i+1] - DO_obs[i+1];
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_mod[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Knx_pi_eu_plrckm.stan
+++ b/inst/models/b_Knx_pi_eu_plrckm.stan
@@ -1,0 +1,119 @@
+// b_Knx_pi_eu_plrckm.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (normal_sdfixed model)
+  real K600_daily_meanlog_meanlog;
+  real<lower=0> K600_daily_meanlog_sdlog;
+  real<lower=0> K600_daily_sdlog;
+  
+  // Error distributions
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  vector<lower=0>[d] K600_daily;
+  
+  real K600_daily_predlog;
+  
+  real<lower=0> err_proc_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Model DO time series
+  // * euler version
+  // * no observation error
+  // * IID process error
+  // * reaeration depends on DO_mod
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  DO_mod_partial[1] = DO_obs_1;
+  DO_mod_partial_sigma[1] = err_proc_iid_sigma * timestep ./ depth[1];
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_obs[i] + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        KO2_inst[i] .* (DO_sat[i] - DO_mod_partial[i])
+      ) * timestep;
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        timestep ./ depth[i,j];
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_obs[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  K600_daily ~ lognormal(K600_daily_predlog, K600_daily_sdlog);
+  // Hierarchical constraints on K600_daily (normal_sdfixed model)
+  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog);
+  
+}
+generated quantities {
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_obs[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Knx_pi_eu_plrcko.stan
+++ b/inst/models/b_Knx_pi_eu_plrcko.stan
@@ -1,0 +1,117 @@
+// b_Knx_pi_eu_plrcko.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (normal_sdfixed model)
+  real K600_daily_meanlog_meanlog;
+  real<lower=0> K600_daily_meanlog_sdlog;
+  real<lower=0> K600_daily_sdlog;
+  
+  // Error distributions
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  vector<lower=0>[d] K600_daily;
+  
+  real K600_daily_predlog;
+  
+  real<lower=0> err_proc_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Model DO time series
+  // * euler version
+  // * no observation error
+  // * IID process error
+  // * reaeration depends on DO_obs
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_obs[i] + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        KO2_inst[i] .* (DO_sat[i] - DO_obs[i])
+      ) * timestep;
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        timestep ./ depth[i,j];
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_obs[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  K600_daily ~ lognormal(K600_daily_predlog, K600_daily_sdlog);
+  // Hierarchical constraints on K600_daily (normal_sdfixed model)
+  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog);
+  
+}
+generated quantities {
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_obs[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Knx_pi_tr_plrckm.stan
+++ b/inst/models/b_Knx_pi_tr_plrckm.stan
@@ -1,0 +1,122 @@
+// b_Knx_pi_tr_plrckm.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (normal_sdfixed model)
+  real K600_daily_meanlog_meanlog;
+  real<lower=0> K600_daily_meanlog_sdlog;
+  real<lower=0> K600_daily_sdlog;
+  
+  // Error distributions
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  vector<lower=0>[d] K600_daily;
+  
+  real K600_daily_predlog;
+  
+  real<lower=0> err_proc_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Model DO time series
+  // * trapezoid version
+  // * no observation error
+  // * IID process error
+  // * reaeration depends on DO_mod
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  DO_mod_partial[1] = DO_obs_1;
+  DO_mod_partial_sigma[1] = err_proc_iid_sigma * timestep ./ depth[1];
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_mod_partial[i] .*
+        (2.0 - KO2_inst[i] * timestep) ./ (2.0 + KO2_inst[i+1] * timestep) + (
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        (GPP_inst[i+1] + ER_inst[i+1]) ./ depth[i+1] +
+        KO2_inst[i] .* DO_sat[i] + KO2_inst[i+1] .* DO_sat[i+1]
+      ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_obs[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  K600_daily ~ lognormal(K600_daily_predlog, K600_daily_sdlog);
+  // Hierarchical constraints on K600_daily (normal_sdfixed model)
+  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog);
+  
+}
+generated quantities {
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_obs[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/inst/models/b_Knx_pi_tr_plrcko.stan
+++ b/inst/models/b_Knx_pi_tr_plrcko.stan
@@ -1,0 +1,120 @@
+// b_Knx_pi_tr_plrcko.stan
+
+data {
+  // Parameters of priors on metabolism
+  real GPP_daily_mu;
+  real GPP_daily_lower;
+  real<lower=0> GPP_daily_sigma;
+  real ER_daily_mu;
+  real ER_daily_upper;
+  real<lower=0> ER_daily_sigma;
+  
+  // Parameters of hierarchical priors on K600_daily (normal_sdfixed model)
+  real K600_daily_meanlog_meanlog;
+  real<lower=0> K600_daily_meanlog_sdlog;
+  real<lower=0> K600_daily_sdlog;
+  
+  // Error distributions
+  real<lower=0> err_proc_iid_sigma_scale;
+  
+  // Data dimensions
+  int<lower=1> d; # number of dates
+  real<lower=0> timestep; # length of each timestep in days
+  int<lower=1> n24; # number of observations in first 24 hours per date
+  int<lower=1> n; # number of observations per date
+  
+  // Daily data
+  vector[d] DO_obs_1;
+  
+  // Data
+  vector[d] DO_obs[n];
+  vector[d] DO_sat[n];
+  vector[d] frac_GPP[n];
+  vector[d] frac_ER[n];
+  vector[d] frac_D[n];
+  vector[d] depth[n];
+  vector[d] KO2_conv[n];
+}
+
+parameters {
+  vector<lower=GPP_daily_lower>[d] GPP_daily;
+  vector<upper=ER_daily_upper>[d] ER_daily;
+  vector<lower=0>[d] K600_daily;
+  
+  real K600_daily_predlog;
+  
+  real<lower=0> err_proc_iid_sigma_scaled;
+}
+
+transformed parameters {
+  vector[d] DO_mod_partial_sigma[n];
+  real<lower=0> err_proc_iid_sigma;
+  vector[d] GPP_inst[n];
+  vector[d] ER_inst[n];
+  vector[d] KO2_inst[n];
+  vector[d] DO_mod_partial[n];
+  
+  // Rescale error distribution parameters
+  err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
+  
+  // Model DO time series
+  // * trapezoid version
+  // * no observation error
+  // * IID process error
+  // * reaeration depends on DO_obs
+  
+  // Calculate individual process rates
+  for(i in 1:n) {
+    GPP_inst[i] = GPP_daily .* frac_GPP[i];
+    ER_inst[i] = ER_daily .* frac_ER[i];
+    KO2_inst[i] = K600_daily .* KO2_conv[i];
+  }
+  
+  // DO model
+  for(i in 1:(n-1)) {
+    DO_mod_partial[i+1] =
+      DO_obs[i] + (
+        - KO2_inst[i] .* DO_obs[i] - KO2_inst[i+1] .* DO_obs[i+1] +
+        (GPP_inst[i] + ER_inst[i]) ./ depth[i] +
+        (GPP_inst[i+1] + ER_inst[i+1]) ./ depth[i+1] +
+        KO2_inst[i] .* DO_sat[i] + KO2_inst[i+1] .* DO_sat[i+1]
+      ) * (timestep / 2.0);
+    for(j in 1:d) {
+      DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
+        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        (timestep / 2.0);
+    }
+  }
+}
+
+model {
+  // Process error
+  for(i in 2:n) {
+    // Independent, identically distributed process error
+    DO_obs[i] ~ normal(DO_mod_partial[i], DO_mod_partial_sigma[i]);
+  }
+  // SD (sigma) of the IID process errors
+  err_proc_iid_sigma_scaled ~ cauchy(0, 1);
+  
+  // Daily metabolism priors
+  GPP_daily ~ normal(GPP_daily_mu, GPP_daily_sigma);
+  ER_daily ~ normal(ER_daily_mu, ER_daily_sigma);
+  K600_daily ~ lognormal(K600_daily_predlog, K600_daily_sdlog);
+  // Hierarchical constraints on K600_daily (normal_sdfixed model)
+  K600_daily_predlog ~ normal(K600_daily_meanlog_meanlog, K600_daily_meanlog_sdlog);
+  
+}
+generated quantities {
+  vector[d] err_proc_iid[n-1];
+  vector[d] GPP;
+  vector[d] ER;
+  
+  for(i in 1:(n-1)) {
+    err_proc_iid[i] = (DO_mod_partial[i+1] - DO_obs[i+1]) .* (err_proc_iid_sigma ./ DO_mod_partial_sigma[i+1]);
+  }
+  for(j in 1:d) {
+    GPP[j] = sum(GPP_inst[1:n24,j]) / n24;
+    ER[j] = sum(ER_inst[1:n24,j]) / n24;
+  }
+  
+}

--- a/man/calc_light_merged.Rd
+++ b/man/calc_light_merged.Rd
@@ -42,21 +42,18 @@ this as a way to smoothly interpolate a time series of observations.
 }
 \examples{
 \dontrun{
-library(mda.streams)
 library(dplyr)
-library(lubridate)
 library(ggplot2)
-library(unitted)
-coords <- get_site_coords('nwis_08062500')
-PAR.obs <- get_ts('par_calcSw', 'nwis_08062500') \%>\%
-  mutate(solar.time = convert_UTC_to_solartime(DateTime, coords$lon)) \%>\%
-    select(solar.time, light=par) \%>\%
-    subset(solar.time \%within\% interval(ymd("2008-03-10"), ymd("2008-03-14"), tz=tz(solar.time)) &
-          !(solar.time \%within\% interval(as.POSIXct("2008-03-12 10:00", tz=tz(solar.time)), 
-                                         as.POSIXct("2008-03-12 14:00", tz=tz(solar.time)))))
-PAR.mod <- u(data.frame(solar.time=seq(as.POSIXct('2008-03-11', tz=tz(PAR.obs$solar.time)),
-    as.POSIXct('2008-03-15', tz=tz(PAR.obs$solar.time)), by=as.difftime(10, units='mins'))) \%>\%
-  mutate(light=calc_light(u(solar.time), latitude=coords$lat, longitude=coords$lon)))
+timebounds <- as.POSIXct(c('2008-03-12 00:00', '2008-03-12 23:59'), tz='UTC')
+coords <- list(lat=32.4, lon=-96.5)
+PAR.obs <- data_frame(
+  solar.time=seq(timebounds[1], timebounds[2], by=as.difftime(3, units='hours')),
+  light=c(0, 0, 85.9, 1160.5, 1539.0, 933.9, 0, 0)
+) \%>\% as.data.frame()
+PAR.mod <- data_frame(
+  solar.time=seq(timebounds[1], timebounds[2], by=as.difftime(0.25, units='hours')),
+  light=calc_light(solar.time, latitude=coords$lat, longitude=coords$lon)
+) \%>\% as.data.frame()
 PAR.merged <- calc_light_merged(PAR.obs, PAR.mod$solar.time, 
   latitude=coords$lat, longitude=coords$lon, max.gap=as.difftime(20, units='hours'))
 ggplot(bind_rows(mutate(v(PAR.obs), type='obs'), mutate(v(PAR.mod), type='mod'), 

--- a/man/mm_generate_mcmc_file.Rd
+++ b/man/mm_generate_mcmc_file.Rd
@@ -5,11 +5,12 @@
 \title{Generate the models in inst/models/bayes}
 \usage{
 mm_generate_mcmc_file(type = "bayes", pool_K600 = c("none", "normal",
-  "linear", "binned"), err_obs_iid = c(TRUE, FALSE),
-  err_proc_acor = c(FALSE, TRUE), err_proc_iid = c(FALSE, TRUE),
-  ode_method = c("trapezoid", "euler"), GPP_fun = c("linlight"),
-  ER_fun = c("constant"), deficit_src = c("DO_mod", "DO_obs"),
-  engine = "stan")
+  "normal_sdzero", "normal_sdfixed", "linear", "linear_sdzero",
+  "linear_sdfixed", "binned", "binned_sdzero", "binned_sdfixed"),
+  err_obs_iid = c(TRUE, FALSE), err_proc_acor = c(FALSE, TRUE),
+  err_proc_iid = c(FALSE, TRUE), ode_method = c("trapezoid", "euler"),
+  GPP_fun = c("linlight"), ER_fun = c("constant"),
+  deficit_src = c("DO_mod", "DO_obs"), engine = "stan")
 }
 \arguments{
 \item{type}{character. The model type. Options:

--- a/man/mm_name.Rd
+++ b/man/mm_name.Rd
@@ -5,13 +5,15 @@
 \title{Find the name of a model by its features}
 \usage{
 mm_name(type = c("mle", "bayes", "night", "Kmodel", "sim"),
-  pool_K600 = c("none", "normal", "linear", "binned", "complete"),
-  err_obs_iid = c(TRUE, FALSE), err_proc_acor = c(FALSE, TRUE),
-  err_proc_iid = c(FALSE, TRUE), ode_method = c("trapezoid", "euler", "rk2",
-  "lsoda", "lsode", "lsodes", "lsodar", "vode", "daspk", "rk4", "ode23",
-  "ode45", "radau", "bdf", "bdf_d", "adams", "impAdams", "impAdams_d", "Euler",
-  "pairmeans", "NA"), GPP_fun = c("linlight", "satlight", "satlightq10temp",
-  "NA"), ER_fun = c("constant", "q10temp", "NA"), deficit_src = c("DO_mod",
+  pool_K600 = c("none", "normal", "normal_sdzero", "normal_sdfixed", "linear",
+  "linear_sdzero", "linear_sdfixed", "binned", "binned_sdzero",
+  "binned_sdfixed", "complete"), err_obs_iid = c(TRUE, FALSE),
+  err_proc_acor = c(FALSE, TRUE), err_proc_iid = c(FALSE, TRUE),
+  ode_method = c("trapezoid", "euler", "rk2", "lsoda", "lsode", "lsodes",
+  "lsodar", "vode", "daspk", "rk4", "ode23", "ode45", "radau", "bdf", "bdf_d",
+  "adams", "impAdams", "impAdams_d", "Euler", "pairmeans", "NA"),
+  GPP_fun = c("linlight", "satlight", "satlightq10temp", "NA"),
+  ER_fun = c("constant", "q10temp", "NA"), deficit_src = c("DO_mod",
   "DO_obs", "DO_obs_filter", "NA"), engine = c("stan", "nlm", "lm", "mean",
   "loess", "rnorm"), check_validity = TRUE)
 }

--- a/man/mm_parse_name.Rd
+++ b/man/mm_parse_name.Rd
@@ -4,13 +4,15 @@
 \alias{mm_parse_name}
 \title{Parse a model name into its features}
 \usage{
-mm_parse_name(model_name, keep_name = FALSE)
+mm_parse_name(model_name, expand = FALSE)
 }
 \arguments{
 \item{model_name}{character: the model name}
 
-\item{keep_name}{logical; should the model_name be included as a first column
-in the output data.frame?}
+\item{expand}{logical: should additional columns such as model_name and
+pool_K600_type be added? If expand=TRUE then the result cannot be passed
+directly back into mm_name, but the additional columns may be helpful for 
+interpreting the model structure.}
 }
 \description{
 Returns a data.frame with one column per model structure detail and one row 
@@ -25,7 +27,7 @@ _v2 is ignored by this function.
 }
 \examples{
 mm_parse_name(c(mm_name('mle'), mm_name('night'), mm_name('bayes')))
-mm_parse_name(c(mm_name('mle'), mm_name('night'), mm_name('bayes')), keep_name=TRUE)
+mm_parse_name(c(mm_name('mle'), mm_name('night'), mm_name('bayes')), expand=TRUE)
 }
 \seealso{
 The converse of this function is \code{\link{mm_name}}.

--- a/man/specs.Rd
+++ b/man/specs.Rd
@@ -12,15 +12,19 @@ specs(model_name = mm_name(), engine, day_start = 4, day_end = 28,
   GPP_daily_lower = -Inf, GPP_daily_sigma = 4, ER_daily_mu = -10,
   ER_daily_upper = Inf, ER_daily_sigma = 5, K600_daily_meanlog = log(6),
   K600_daily_meanlog_meanlog = log(6), K600_daily_meanlog_sdlog = 1,
+  lnK600_lnQ_intercept_mu = 2, lnK600_lnQ_intercept_sigma = 2.4,
+  lnK600_lnQ_slope_mu = 0, lnK600_lnQ_slope_sigma = 0.5,
+  K600_lnQ_nodes_centers = -3:3, K600_lnQ_nodediffs_sdlog = 0.05,
+  K600_lnQ_nodes_meanlog = rep(log(6), length(K600_lnQ_nodes_centers)),
+  K600_lnQ_nodes_sdlog = rep(1, length(K600_lnQ_nodes_centers)),
   K600_daily_sdlog = switch(mm_parse_name(model_name)$pool_K600, none = 1,
-  normal = 0.2, default = NA),
-  K600_daily_sigma = switch(mm_parse_name(model_name)$pool_K600, linear = 10,
-  binned = 5, default = NA), lnK600_lnQ_intercept_mu = 2,
-  lnK600_lnQ_intercept_sigma = 2.4, lnK600_lnQ_slope_mu = 0,
-  lnK600_lnQ_slope_sigma = 0.5, K600_lnQ_nodes_centers = -3:3,
-  K600_lnQ_nodediffs_sdlog = 0.05, K600_lnQ_nodes_meanlog = rep(log(6),
-  length(K600_lnQ_nodes_centers)), K600_lnQ_nodes_sdlog = rep(1,
-  length(K600_lnQ_nodes_centers)), err_obs_iid_sigma_scale = 0.1,
+  normal_sdfixed = 0.05, NA),
+  K600_daily_sigma = switch(mm_parse_name(model_name)$pool_K600,
+  linear_sdfixed = 10, binned_sdfixed = 5, NA),
+  K600_daily_sdlog_sigma = switch(mm_parse_name(model_name)$pool_K600, normal
+  = 0.05, NA),
+  K600_daily_sigma_sigma = switch(mm_parse_name(model_name)$pool_K600, linear
+  = 5, binned = 2, NA), err_obs_iid_sigma_scale = 0.1,
   err_proc_acor_phi_alpha = 1, err_proc_acor_phi_beta = 1,
   err_proc_acor_sigma_scale = 0.1, err_proc_iid_sigma_scale = 0.1,
   params_in, params_out, n_chains = 4, n_cores = 4, burnin_steps = 500,
@@ -146,7 +150,7 @@ rate of gross primary production}
 \item{GPP_daily_lower}{The lower bound on every fitted value of GPP_daily, 
 the daily rate of gross primary production. Use values other than -Inf with
 caution, recognizing that sometimes the input data are unmodelable and that
-a negative estimate of GPP_daily (when unconstrained) could be your only
+a negative estimate of GPP_daily (when unconstrained) could be your only 
 indication.}
 
 \item{GPP_daily_sigma}{The standard deviation of a dnorm distribution for 
@@ -175,17 +179,6 @@ K ~ lN(meanlog, sdlog), meanlog ~ lN(meanlog_meanlog, meanlog_sdlog)}
 standard deviation parameter (meanlog_sdlog) of a lognormal distribution of
 meanlog in K ~ lN(meanlog, sdlog), meanlog ~ lN(meanlog_meanlog, 
 meanlog_sdlog)}
-
-\item{K600_daily_sdlog}{The lognormal scale parameter (standard deviation) of
-a dlnorm distribution having meanlog equal to \code{K600_daily_meanlog} 
-(when pool_K600 is 'none') or \code{K600_daily_predlog} (when pool_K600 is 
-'normal') for K600_daily, the daily rate of reaeration as corrected for 
-temperature and the diffusivity of oxygen}
-
-\item{K600_daily_sigma}{The standard deviation of a dnorm distribution having
-mean equal to \code{exp(K600_daily_predlog)} (applicable when pool_K600 is 
-'linear' or 'binned') for K600_daily, the daily rate of reaeration as 
-corrected for temperature and the diffusivity of oxygen}
 
 \item{lnK600_lnQ_intercept_mu}{hyperparameter for pool_K600 == 'linear'. The 
 mean of the prior distribution for the intercept parameter in 
@@ -218,6 +211,28 @@ means of lognormal prior distributions for the K600_lnQ_nodes parameters.}
 \item{K600_lnQ_nodes_sdlog}{hyperparameter for pool_K600='binned'. The 
 standard deviations of lognormal prior distributions for the K600_lnQ_nodes
 parameters.}
+
+\item{K600_daily_sdlog}{The lognormal scale parameter (standard deviation) of
+a dlnorm distribution having meanlog equal to \code{K600_daily_meanlog} 
+(when pool_K600 is 'none') or \code{K600_daily_predlog} (when pool_K600 is 
+'normal_sdfixed') for K600_daily, the daily rate of reaeration as corrected
+for temperature and the diffusivity of oxygen}
+
+\item{K600_daily_sigma}{The standard deviation of a dnorm distribution having
+mean equal to \code{exp(K600_daily_predlog)} (applicable when pool_K600 is 
+'linear_sdfixed' or 'binned_sdfixed') for K600_daily, the daily rate of 
+reaeration as corrected for temperature and the diffusivity of oxygen}
+
+\item{K600_daily_sdlog_sigma}{hyperparameter for pool_K600 in c('normal'). 
+The scale (= sigma) parameter of a half-normal distribution of sdlog in K ~
+lN(meanlog, sdlog), sdlog ~ halfnormal(0, sigma=sdlog_sigma). Visualize the
+PDF of K600_daily_sdlog with \code{\link{plot_distribs}}.}
+
+\item{K600_daily_sigma_sigma}{hyperparameter for pool_K600 in 
+c('linear','binned'). The scale (= sigma) parameter of a half-normal 
+distribution of sigma in K ~ lN(meanlog, sigma), sigma ~ halfnormal(0, 
+sigma=sigma_sigma). Visualize the PDF of K600_daily_sdlog with 
+\code{\link{plot_distribs}}.}
 
 \item{err_obs_iid_sigma_scale}{The scale (= sigma) parameter of a half-Cauchy
 distribution for err_obs_iid_sigma, the standard deviation of the 
@@ -402,15 +417,15 @@ often should, be overridden to tailor the model to your needs.
   n_chains, n_cores, burnin_steps, saved_steps, thin_steps, verbose}. The 
   need for other arguments depends on features of the model structure, as 
   from \code{mm_parse_name(model_name)}: \itemize{ \item If 
-  \code{$pool_K600=='none'} then \code{K600_daily_meanlog, K600_daily_sdlog}.
-  \item If \code{$pool_K600=='normal'} then \code{K600_daily_meanlog_meanlog,
-  K600_daily_meanlog_sdlog, K600_daily_sdlog}. \item If 
+  \code{pool_K600=='none'} then \code{K600_daily_meanlog, K600_daily_sdlog}. 
+  \item If \code{pool_K600=='normal'} then \code{K600_daily_meanlog_meanlog, 
+  K600_daily_meanlog_sdlog, K600_daily_sdlog_sigma}. \item If 
   \code{pool_K600=='linear'} then \code{lnK600_lnQ_intercept_mu, 
   lnK600_lnQ_intercept_sigma, lnK600_lnQ_slope_mu, lnK600_lnQ_slope_sigma, 
-  K600_daily_sigma}. \item If \code{pool_K600=='binned'} then 
+  K600_daily_sigma_sigma}. \item If \code{pool_K600=='binned'} then 
   \code{K600_lnQ_nodes_centers, K600_lnQ_nodediffs_sdlog, 
-  K600_lnQ_nodes_meanlog, K600_lnQ_nodes_sdlog, K600_daily_sigma}. \item If 
-  \code{err_obs_iid} then \code{err_obs_iid_sigma_scale}. \item If 
+  K600_lnQ_nodes_meanlog, K600_lnQ_nodes_sdlog, K600_daily_sigma_sigma}. 
+  \item If \code{err_obs_iid} then \code{err_obs_iid_sigma_scale}. \item If 
   \code{err_proc_acor} then \code{err_proc_acor_phi_alpha, 
   err_proc_acor_phi_beta, err_proc_acor_sigma_scale}. \item If 
   \code{err_proc_iid} then \code{ err_proc_iid_sigma_scale}.}


### PR DESCRIPTION
it's now possible to fit K600_daily_sigma, to fix it to a user-specified value, or to fix it to 0.

`calc_light_merged` was approximating the correction factors wrong for when observed light > modeled. This should be a fairly rare case, but still...