### PR TITLE
use native CIs for bayesian models in get_params

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: streamMetabolizer
 Type: Package
 Title: Models for Estimating Aquatic Photosynthesis and Respiration
-Version: 0.9.36
-Date: 2017-01-27
+Version: 0.9.37
+Date: 2017-01-30
 Author: Alison P. Appling, Robert O. Hall, Maite Arroita, and Charles B.
     Yackulic
 Authors@R: c(

--- a/R/metab_bayes.R
+++ b/R/metab_bayes.R
@@ -966,6 +966,7 @@ get_params.metab_bayes <- function(metab_model, date_start=NA, date_end=NA, unce
   }
   names(metab_model@fit$daily) <- gsub('_mean$', '', names(metab_model@fit$daily))
   names(metab_model@fit$daily) <- gsub('_sd$', '.sd', names(metab_model@fit$daily))
+  names(metab_model@fit$daily) <- gsub('_50pct$', '.median', names(metab_model@fit$daily))
   names(metab_model@fit$daily) <- gsub('_2.5pct$', '.lower', names(metab_model@fit$daily))
   names(metab_model@fit$daily) <- gsub('_97.5pct$', '.upper', names(metab_model@fit$daily))
   # code duplicated in get_params.metab_Kmodel:
@@ -979,6 +980,6 @@ get_params.metab_bayes <- function(metab_model, date_start=NA, date_end=NA, unce
     dmsg <- metab_model@fit$daily$errors
     metab_model@fit$daily$errors <- ifelse(dmsg == '', omsg, paste(omsg, dmsg, sep=';'))
   }
-  metab_model@fit <- metab_model@fit$daily # SUPER-TEMPORARY we're still converting fit$daily to fit until #247, #229
+  metab_model@fit <- metab_model@fit$daily # TEMPORARY we're still converting fit$daily to fit until #247, #229
   NextMethod()
 }

--- a/R/metab_model_interface.R
+++ b/R/metab_model_interface.R
@@ -163,7 +163,10 @@ get_version <- function(metab_model) {
 #' @param uncertainty character. Should columns for the uncertainty of parameter
 #'   estimates be excluded ('none'), reported as standard deviations ('sd'), or 
 #'   reported as lower and upper bounds of a 95 percent confidence interval 
-#'   ('ci')?
+#'   ('ci')? When available (e.g., for Bayesian models), if 'ci' then the 
+#'   central value will be the median (50th quantile) and the ranges will be the
+#'   2.5th and 97.5th quantiles. If 'sd' then the central value will always be 
+#'   the mean.
 #' @param messages logical. Should warning and error messages from the fitting 
 #'   procedure be included in the output?
 #' @param fixed character. Should values pulled from data_daily (i.e., fixed 

--- a/man/get_params.Rd
+++ b/man/get_params.Rd
@@ -42,7 +42,10 @@ metab_model_interface, to use in predicting metabolism}
 \item{uncertainty}{character. Should columns for the uncertainty of parameter
 estimates be excluded ('none'), reported as standard deviations ('sd'), or 
 reported as lower and upper bounds of a 95 percent confidence interval 
-('ci')?}
+('ci')? When available (e.g., for Bayesian models), if 'ci' then the 
+central value will be the median (50th quantile) and the ranges will be the
+2.5th and 97.5th quantiles. If 'sd' then the central value will always be 
+the mean.}
 
 \item{messages}{logical. Should warning and error messages from the fitting 
 procedure be included in the output?}


### PR DESCRIPTION
for bayesian models:
if uncertainty='sd', returns mean and sd for each parameter
if uncertainty='ci', returns 2.5, 50, and 97.5% quantiles for each parameter

for other models:
if uncertainty='sd', returns mean and sd for each parameter
if uncertainty='ci', mean and c(-1.96, +1.96)*sd for each parameter
