### PR TITLE
debugging for condor run3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: streamMetabolizer
 Type: Package
 Title: Models for Estimating Aquatic Photosynthesis and Respiration
-Version: 0.10.0
-Date: 2017-03-07
+Version: 0.10.1
+Date: 2017-04-07
 Author: Alison P. Appling, Robert O. Hall, Maite Arroita, and Charles B.
     Yackulic
 Authors@R: c(

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: streamMetabolizer
 Type: Package
 Title: Models for Estimating Aquatic Photosynthesis and Respiration
 Version: 0.10.1
-Date: 2017-04-07
+Date: 2017-04-10
 Author: Alison P. Appling, Robert O. Hall, Maite Arroita, and Charles B.
     Yackulic
 Authors@R: c(
@@ -41,7 +41,7 @@ Imports:
     methods,
     tibble (>= 1.1.0),
     tidyr,
-    unitted (>= 0.2.6)
+    unitted (>= 0.2.8)
 Suggests:
     chron,
     devtools,

--- a/R/01-onLoad.R
+++ b/R/01-onLoad.R
@@ -65,6 +65,7 @@ define_pkg_env <- function() {
   pkg.env <- new.env()
   pkg.env$tz_lookups <- list(
     # populate with values that are used in test-convert.R and load_french_creek.R
+    "51.5000000000,-120.0000000000"=list(tz="America/Vancouver", dst_offset=u(0,"hours"), std_offset=u(8,"hours"), retry=0),
     "51.4800000000,-0.0000000000"=list(tz="Europe/London", dst_offset=u(0,"hours"), std_offset=u(0,"hours"), retry=0),
     "41.0000000000,105.3000000000"=list(tz="Asia/Shanghai", dst_offset=u(0,"hours"), std_offset=u(8,"hours"), retry=0),
     "37.0000000000,-105.3000000000"=list(tz="America/Denver", dst_offset=u(0,"hours"), std_offset=u(-7,"hours"), retry=0),

--- a/R/metab_bayes.R
+++ b/R/metab_bayes.R
@@ -370,11 +370,11 @@ bayes_allply <- function(
   # match date and time info to indices
   date_df <- data_frame(
     date=as.Date(unique(data_all$date)),
-    date_index=seq_len(data_list$d))
+    date_index=seq_along(data_list$d))
   datetime_df <- data_frame(
     solar.time=data_all$solar.time,
-    date_index=rep(seq_len(data_list$d), each=data_list$n),
-    time_index=rep(seq_len(data_list$n), times=data_list$d))
+    date_index=rep(seq_along(data_list$d), each=data_list$n),
+    time_index=rep(seq_along(data_list$n), times=data_list$d))
   
   # stop_strs may have accumulated during prepdata_bayes() or runstan_bayes()
   # calls. If failed, use dummy data to fill in the model output with NAs.

--- a/R/metab_bayes.R
+++ b/R/metab_bayes.R
@@ -370,11 +370,11 @@ bayes_allply <- function(
   # match date and time info to indices
   date_df <- data_frame(
     date=as.Date(unique(data_all$date)),
-    date_index=seq_along(data_list$d))
+    date_index=seq_len(data_list$d))
   datetime_df <- data_frame(
     solar.time=data_all$solar.time,
-    date_index=rep(seq_along(data_list$d), each=data_list$n),
-    time_index=rep(seq_along(data_list$n), times=data_list$d))
+    date_index=rep(seq_len(data_list$d), each=data_list$n),
+    time_index=rep(seq_len(data_list$n), times=data_list$d))
   
   # stop_strs may have accumulated during prepdata_bayes() or runstan_bayes()
   # calls. If failed, use dummy data to fill in the model output with NAs.

--- a/R/metab_model.predict_metab.R
+++ b/R/metab_model.predict_metab.R
@@ -76,7 +76,7 @@ predict_metab.metab_model <- function(
     # mean metabolism. no need to test days again unless we didn't do it during
     # fitting (which only occurs for sim)
     day_tests_pred <- if(mm_parse_name(specs$model_name)$type == 'sim') specs$day_tests else c() 
-    req_ts_pred <- if(mm_parse_name(specs$model_name)$type == 'sim') specs$required_timestep else c() 
+    req_ts_pred <- if(mm_parse_name(specs$model_name)$type == 'sim') specs$required_timestep else NA 
     preds <- mm_model_by_ply(
       mm_predict_metab_1ply, data=data, data_daily=metab_ests, # for mm_model_by_ply
       day_start=day_start, day_end=day_end, day_tests=day_tests_pred, required_timestep=req_ts_pred, timestep_days=FALSE, # for mm_model_by_ply

--- a/R/mm_is_valid_day.R
+++ b/R/mm_is_valid_day.R
@@ -42,12 +42,12 @@ mm_is_valid_day <- function(
   day_start=4, day_end=27.99, # inheritParams mm_model_by_ply
   day_tests=c('full_day', 'even_timesteps', 'complete_data', 'pos_discharge'), 
   required_timestep=NA,
-  ply_date=as.Date(format(data_ply[nrow(data_ply)/2,'solar.time'], "%Y-%m-%d")),
+  ply_date=as.Date(format(data_ply[max(1,nrow(data_ply)/2),'solar.time'], "%Y-%m-%d")),
   timestep_days=NA
 ) {
   
   # check input
-  if(!missing(day_tests) && length(day_tests) == 0) return(TRUE)
+  if(!missing(day_tests) && length(day_tests) == 0 && is.na(required_timestep[1])) return(TRUE)
   day_tests <- match.arg(day_tests, several.ok = TRUE)
   day_start <- as.difftime(day_start, units="hours")
   day_end <- as.difftime(day_end, units="hours")
@@ -67,7 +67,7 @@ mm_is_valid_day <- function(
     } else {
       timestep_days
     }
-    if(length(timestep.days) == 0) {
+    if(length(timestep.days) == 0 || !is.finite(timestep.days)) {
       stop_strs <- c(stop_strs, "no timesteps")
       timestep.days <- NA
     }

--- a/R/mm_is_valid_day.R
+++ b/R/mm_is_valid_day.R
@@ -99,8 +99,8 @@ mm_is_valid_day <- function(
   }
   
   # Require the actual average timestep to match the value specified in
-  # required_timestep (within tolerance of 0.2% of required_timestep length)
-  if(!isTRUE(is.na(required_timestep)) & is.finite(timestep.days)) {
+  # required_timestep (within tolerance ocf 0.2% of required_timestep length)
+  if(!isTRUE(is.na(required_timestep)) && is.finite(timestep.days)) {
     if(length(required_timestep) != 1 || !is.numeric(required_timestep)) {
       stop('expecting required_timestep as single numeric value (or NA)')
     }

--- a/man/mm_is_valid_day.Rd
+++ b/man/mm_is_valid_day.Rd
@@ -7,7 +7,7 @@
 mm_is_valid_day(data_ply, day_start = 4, day_end = 27.99,
   day_tests = c("full_day", "even_timesteps", "complete_data",
   "pos_discharge"), required_timestep = NA,
-  ply_date = as.Date(format(data_ply[nrow(data_ply)/2, "solar.time"],
+  ply_date = as.Date(format(data_ply[max(1, nrow(data_ply)/2), "solar.time"],
   "\%Y-\%m-\%d")), timestep_days = NA)
 }
 \arguments{

--- a/tests/testthat/test-metab_helpers.R
+++ b/tests/testthat/test-metab_helpers.R
@@ -78,7 +78,7 @@ test_that("mm_is_valid_day works", {
   
   # test faulty timestep
   dateless_day <- good_day; dateless_day$solar.time <- replace(dateless_day$solar.time, 2:(nrow(dateless_day)-1), NA)
-  expect_equal(mm_is_valid_day(dateless_day), c("NAs in solar.time"))
+  expect_equal(mm_is_valid_day(dateless_day), c("no timesteps", "NAs in solar.time"))
   
   # test full_day
   expect_equal(mm_is_valid_day(good_day, day_start=-10, day_end=30), "data don't start when expected")


### PR DESCRIPTION
was getting this in condor run attempts for some sites:
```r
error in model run: in seq_len(data_list$d): argument must be coercible to non-negative integer
```

d was NULL because date filtering in `mm_is_valid_day` was missing edge case of 1+ days with exactly 1 observation. updated the test.