### PR TITLE
minor maintenance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,11 @@ before_script:
 r_packages:
  - modeest
  - deSolve
+ - rstan
 
 r_github_packages:
  - jimhester/covr
  - GLEON/LakeMetabolizer
- - appling/unitted
 
 after_success:
   - if [[ "${R_CODECOV}" ]]; then travis_wait 20 R -e 'covr::coveralls()'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ r_github_packages:
  - appling/unitted
 
 after_success:
-  - Rscript -e 'covr::coveralls()'
+  - if [[ "${R_CODECOV}" ]]; then travis_wait 20 R -e 'covr::coveralls()'; fi
 
 after_failure:
   - ./travis-tool.sh dump_logs

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,13 @@ sudo: required
 dist: trusty
 warnings_are_errors: true
 
-r_build_args: --no-build-vignettes --no-manual --no-multiarch
-r_check_args: --no-build-vignettes --no-manual
+env:
+   global:
+     - R_BUILD_ARGS="--no-build-vignettes --no-manual --no-multiarch"
+     - R_CHECK_ARGS="--no-build-vignettes --no-manual --as-cran"
+     - NOT_CRAN="true"
+     - _R_CHECK_FORCE_SUGGESTS_=false
+   
 
 repos:
   CRAN: https://cran.rstudio.com
@@ -26,6 +31,12 @@ r_packages:
 r_github_packages:
  - jimhester/covr
  - GLEON/LakeMetabolizer
+
+script:
+  - |
+    R CMD build ${R_BUILD_ARGS} .
+    PKG_FILE_NAME=$(ls -1t *.tar.gz | head -n 1)
+    travis_wait 20 R CMD check ${R_CHECK_ARGS} "${PKG_FILE_NAME}"
 
 after_success:
   - if [[ "${R_CODECOV}" ]]; then travis_wait 20 R -e 'covr::coveralls()'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@
 
 language: r
 sudo: required
+dist: trusty
 warnings_are_errors: true
 
 r_build_args: --no-build-vignettes --no-manual --no-multiarch

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: streamMetabolizer
 Type: Package
 Title: Models for Estimating Aquatic Photosynthesis and Respiration
-Version: 0.10.4
-Date: 2017-06-16
+Version: 0.10.5
+Date: 2017-07-18
 Author: Alison P. Appling, Robert O. Hall, Maite Arroita, and Charles B.
     Yackulic
 Authors@R: c(

--- a/R/metab_bayes.R
+++ b/R/metab_bayes.R
@@ -374,7 +374,8 @@ bayes_allply <- function(
   datetime_df <- data_frame(
     solar.time=data_all$solar.time,
     date_index=rep(seq_len(data_list$d), each=data_list$n),
-    time_index=rep(seq_len(data_list$n), times=data_list$d))
+    time_index=rep(seq_len(data_list$n), times=data_list$d)) %>%
+    left_join(date_df, by='date_index')
   
   # stop_strs may have accumulated during prepdata_bayes() or runstan_bayes()
   # calls. If failed, use dummy data to fill in the model output with NAs.
@@ -399,7 +400,7 @@ bayes_allply <- function(
       bayes_allday$inst <- bayes_allday$inst %>% 
         left_join(datetime_df, by=c('date_index','time_index')) %>% 
         select(-date_index, -time_index, -index) %>% 
-        select(solar.time, everything())
+        select(date, solar.time, everything())
     }
   }
 

--- a/R/mm_generate_mcmc_file.R
+++ b/R/mm_generate_mcmc_file.R
@@ -147,7 +147,7 @@ mm_generate_mcmc_file <- function(
             'real lnK600_lnQ_slope_mu;',
             'real<lower=0> lnK600_lnQ_slope_sigma;'),
           binned=c(
-            'int <lower=1> b; # number of K600_lnQ_nodes',
+            'int <lower=1> b; // number of K600_lnQ_nodes',
             'real K600_lnQ_nodediffs_sdlog;',
             'vector[b] K600_lnQ_nodes_meanlog;',
             'vector[b] K600_lnQ_nodes_sdlog;')
@@ -179,10 +179,10 @@ mm_generate_mcmc_file <- function(
       
       chunk(
         comment('Data dimensions'),
-        'int<lower=1> d; # number of dates',
-        'real<lower=0> timestep; # length of each timestep in days',
-        'int<lower=1> n24; # number of observations in first 24 hours per date',
-        'int<lower=1> n; # number of observations per date'),
+        'int<lower=1> d; // number of dates',
+        'real<lower=0> timestep; // length of each timestep in days',
+        'int<lower=1> n24; // number of observations in first 24 hours per date',
+        'int<lower=1> n; // number of observations per date'),
       
       chunk(
         comment('Daily data'),

--- a/inst/models/b_Kb0_oi_eu_plrckm.stan
+++ b/inst/models/b_Kb0_oi_eu_plrckm.stan
@@ -10,7 +10,7 @@ data {
   real<lower=0> ER_daily_sigma;
   
   // Parameters of hierarchical priors on K600_daily (binned_sdzero model)
-  int <lower=1> b; # number of K600_lnQ_nodes
+  int <lower=1> b; // number of K600_lnQ_nodes
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
@@ -19,10 +19,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kb0_oi_eu_plrcko.stan
+++ b/inst/models/b_Kb0_oi_eu_plrcko.stan
@@ -10,7 +10,7 @@ data {
   real<lower=0> ER_daily_sigma;
   
   // Parameters of hierarchical priors on K600_daily (binned_sdzero model)
-  int <lower=1> b; # number of K600_lnQ_nodes
+  int <lower=1> b; // number of K600_lnQ_nodes
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
@@ -19,10 +19,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kb0_oi_tr_plrckm.stan
+++ b/inst/models/b_Kb0_oi_tr_plrckm.stan
@@ -10,7 +10,7 @@ data {
   real<lower=0> ER_daily_sigma;
   
   // Parameters of hierarchical priors on K600_daily (binned_sdzero model)
-  int <lower=1> b; # number of K600_lnQ_nodes
+  int <lower=1> b; // number of K600_lnQ_nodes
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
@@ -19,10 +19,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kb0_oi_tr_plrcko.stan
+++ b/inst/models/b_Kb0_oi_tr_plrcko.stan
@@ -10,7 +10,7 @@ data {
   real<lower=0> ER_daily_sigma;
   
   // Parameters of hierarchical priors on K600_daily (binned_sdzero model)
-  int <lower=1> b; # number of K600_lnQ_nodes
+  int <lower=1> b; // number of K600_lnQ_nodes
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
@@ -19,10 +19,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kb0_oipi_eu_plrckm.stan
+++ b/inst/models/b_Kb0_oipi_eu_plrckm.stan
@@ -10,7 +10,7 @@ data {
   real<lower=0> ER_daily_sigma;
   
   // Parameters of hierarchical priors on K600_daily (binned_sdzero model)
-  int <lower=1> b; # number of K600_lnQ_nodes
+  int <lower=1> b; // number of K600_lnQ_nodes
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kb0_oipi_eu_plrcko.stan
+++ b/inst/models/b_Kb0_oipi_eu_plrcko.stan
@@ -10,7 +10,7 @@ data {
   real<lower=0> ER_daily_sigma;
   
   // Parameters of hierarchical priors on K600_daily (binned_sdzero model)
-  int <lower=1> b; # number of K600_lnQ_nodes
+  int <lower=1> b; // number of K600_lnQ_nodes
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kb0_oipi_tr_plrckm.stan
+++ b/inst/models/b_Kb0_oipi_tr_plrckm.stan
@@ -10,7 +10,7 @@ data {
   real<lower=0> ER_daily_sigma;
   
   // Parameters of hierarchical priors on K600_daily (binned_sdzero model)
-  int <lower=1> b; # number of K600_lnQ_nodes
+  int <lower=1> b; // number of K600_lnQ_nodes
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kb0_oipi_tr_plrcko.stan
+++ b/inst/models/b_Kb0_oipi_tr_plrcko.stan
@@ -10,7 +10,7 @@ data {
   real<lower=0> ER_daily_sigma;
   
   // Parameters of hierarchical priors on K600_daily (binned_sdzero model)
-  int <lower=1> b; # number of K600_lnQ_nodes
+  int <lower=1> b; // number of K600_lnQ_nodes
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kb0_pi_eu_plrckm.stan
+++ b/inst/models/b_Kb0_pi_eu_plrckm.stan
@@ -10,7 +10,7 @@ data {
   real<lower=0> ER_daily_sigma;
   
   // Parameters of hierarchical priors on K600_daily (binned_sdzero model)
-  int <lower=1> b; # number of K600_lnQ_nodes
+  int <lower=1> b; // number of K600_lnQ_nodes
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
@@ -19,10 +19,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kb0_pi_eu_plrcko.stan
+++ b/inst/models/b_Kb0_pi_eu_plrcko.stan
@@ -10,7 +10,7 @@ data {
   real<lower=0> ER_daily_sigma;
   
   // Parameters of hierarchical priors on K600_daily (binned_sdzero model)
-  int <lower=1> b; # number of K600_lnQ_nodes
+  int <lower=1> b; // number of K600_lnQ_nodes
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
@@ -19,10 +19,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kb0_pi_tr_plrckm.stan
+++ b/inst/models/b_Kb0_pi_tr_plrckm.stan
@@ -10,7 +10,7 @@ data {
   real<lower=0> ER_daily_sigma;
   
   // Parameters of hierarchical priors on K600_daily (binned_sdzero model)
-  int <lower=1> b; # number of K600_lnQ_nodes
+  int <lower=1> b; // number of K600_lnQ_nodes
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
@@ -19,10 +19,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kb0_pi_tr_plrcko.stan
+++ b/inst/models/b_Kb0_pi_tr_plrcko.stan
@@ -10,7 +10,7 @@ data {
   real<lower=0> ER_daily_sigma;
   
   // Parameters of hierarchical priors on K600_daily (binned_sdzero model)
-  int <lower=1> b; # number of K600_lnQ_nodes
+  int <lower=1> b; // number of K600_lnQ_nodes
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
@@ -19,10 +19,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kb_oi_eu_plrckm.stan
+++ b/inst/models/b_Kb_oi_eu_plrckm.stan
@@ -10,7 +10,7 @@ data {
   real<lower=0> ER_daily_sigma;
   
   // Parameters of hierarchical priors on K600_daily (binned model)
-  int <lower=1> b; # number of K600_lnQ_nodes
+  int <lower=1> b; // number of K600_lnQ_nodes
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kb_oi_eu_plrcko.stan
+++ b/inst/models/b_Kb_oi_eu_plrcko.stan
@@ -10,7 +10,7 @@ data {
   real<lower=0> ER_daily_sigma;
   
   // Parameters of hierarchical priors on K600_daily (binned model)
-  int <lower=1> b; # number of K600_lnQ_nodes
+  int <lower=1> b; // number of K600_lnQ_nodes
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kb_oi_tr_plrckm.stan
+++ b/inst/models/b_Kb_oi_tr_plrckm.stan
@@ -10,7 +10,7 @@ data {
   real<lower=0> ER_daily_sigma;
   
   // Parameters of hierarchical priors on K600_daily (binned model)
-  int <lower=1> b; # number of K600_lnQ_nodes
+  int <lower=1> b; // number of K600_lnQ_nodes
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kb_oi_tr_plrcko.stan
+++ b/inst/models/b_Kb_oi_tr_plrcko.stan
@@ -10,7 +10,7 @@ data {
   real<lower=0> ER_daily_sigma;
   
   // Parameters of hierarchical priors on K600_daily (binned model)
-  int <lower=1> b; # number of K600_lnQ_nodes
+  int <lower=1> b; // number of K600_lnQ_nodes
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kb_oipi_eu_plrckm.stan
+++ b/inst/models/b_Kb_oipi_eu_plrckm.stan
@@ -10,7 +10,7 @@ data {
   real<lower=0> ER_daily_sigma;
   
   // Parameters of hierarchical priors on K600_daily (binned model)
-  int <lower=1> b; # number of K600_lnQ_nodes
+  int <lower=1> b; // number of K600_lnQ_nodes
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
@@ -21,10 +21,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kb_oipi_eu_plrcko.stan
+++ b/inst/models/b_Kb_oipi_eu_plrcko.stan
@@ -10,7 +10,7 @@ data {
   real<lower=0> ER_daily_sigma;
   
   // Parameters of hierarchical priors on K600_daily (binned model)
-  int <lower=1> b; # number of K600_lnQ_nodes
+  int <lower=1> b; // number of K600_lnQ_nodes
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
@@ -21,10 +21,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kb_oipi_tr_plrckm.stan
+++ b/inst/models/b_Kb_oipi_tr_plrckm.stan
@@ -10,7 +10,7 @@ data {
   real<lower=0> ER_daily_sigma;
   
   // Parameters of hierarchical priors on K600_daily (binned model)
-  int <lower=1> b; # number of K600_lnQ_nodes
+  int <lower=1> b; // number of K600_lnQ_nodes
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
@@ -21,10 +21,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kb_oipi_tr_plrcko.stan
+++ b/inst/models/b_Kb_oipi_tr_plrcko.stan
@@ -10,7 +10,7 @@ data {
   real<lower=0> ER_daily_sigma;
   
   // Parameters of hierarchical priors on K600_daily (binned model)
-  int <lower=1> b; # number of K600_lnQ_nodes
+  int <lower=1> b; // number of K600_lnQ_nodes
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
@@ -21,10 +21,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kb_pi_eu_plrckm.stan
+++ b/inst/models/b_Kb_pi_eu_plrckm.stan
@@ -10,7 +10,7 @@ data {
   real<lower=0> ER_daily_sigma;
   
   // Parameters of hierarchical priors on K600_daily (binned model)
-  int <lower=1> b; # number of K600_lnQ_nodes
+  int <lower=1> b; // number of K600_lnQ_nodes
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kb_pi_eu_plrcko.stan
+++ b/inst/models/b_Kb_pi_eu_plrcko.stan
@@ -10,7 +10,7 @@ data {
   real<lower=0> ER_daily_sigma;
   
   // Parameters of hierarchical priors on K600_daily (binned model)
-  int <lower=1> b; # number of K600_lnQ_nodes
+  int <lower=1> b; // number of K600_lnQ_nodes
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kb_pi_tr_plrckm.stan
+++ b/inst/models/b_Kb_pi_tr_plrckm.stan
@@ -10,7 +10,7 @@ data {
   real<lower=0> ER_daily_sigma;
   
   // Parameters of hierarchical priors on K600_daily (binned model)
-  int <lower=1> b; # number of K600_lnQ_nodes
+  int <lower=1> b; // number of K600_lnQ_nodes
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kb_pi_tr_plrcko.stan
+++ b/inst/models/b_Kb_pi_tr_plrcko.stan
@@ -10,7 +10,7 @@ data {
   real<lower=0> ER_daily_sigma;
   
   // Parameters of hierarchical priors on K600_daily (binned model)
-  int <lower=1> b; # number of K600_lnQ_nodes
+  int <lower=1> b; // number of K600_lnQ_nodes
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kbx_oi_eu_plrckm.stan
+++ b/inst/models/b_Kbx_oi_eu_plrckm.stan
@@ -10,7 +10,7 @@ data {
   real<lower=0> ER_daily_sigma;
   
   // Parameters of hierarchical priors on K600_daily (binned_sdfixed model)
-  int <lower=1> b; # number of K600_lnQ_nodes
+  int <lower=1> b; // number of K600_lnQ_nodes
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kbx_oi_eu_plrcko.stan
+++ b/inst/models/b_Kbx_oi_eu_plrcko.stan
@@ -10,7 +10,7 @@ data {
   real<lower=0> ER_daily_sigma;
   
   // Parameters of hierarchical priors on K600_daily (binned_sdfixed model)
-  int <lower=1> b; # number of K600_lnQ_nodes
+  int <lower=1> b; // number of K600_lnQ_nodes
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kbx_oi_tr_plrckm.stan
+++ b/inst/models/b_Kbx_oi_tr_plrckm.stan
@@ -10,7 +10,7 @@ data {
   real<lower=0> ER_daily_sigma;
   
   // Parameters of hierarchical priors on K600_daily (binned_sdfixed model)
-  int <lower=1> b; # number of K600_lnQ_nodes
+  int <lower=1> b; // number of K600_lnQ_nodes
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kbx_oi_tr_plrcko.stan
+++ b/inst/models/b_Kbx_oi_tr_plrcko.stan
@@ -10,7 +10,7 @@ data {
   real<lower=0> ER_daily_sigma;
   
   // Parameters of hierarchical priors on K600_daily (binned_sdfixed model)
-  int <lower=1> b; # number of K600_lnQ_nodes
+  int <lower=1> b; // number of K600_lnQ_nodes
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kbx_oipi_eu_plrckm.stan
+++ b/inst/models/b_Kbx_oipi_eu_plrckm.stan
@@ -10,7 +10,7 @@ data {
   real<lower=0> ER_daily_sigma;
   
   // Parameters of hierarchical priors on K600_daily (binned_sdfixed model)
-  int <lower=1> b; # number of K600_lnQ_nodes
+  int <lower=1> b; // number of K600_lnQ_nodes
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
@@ -21,10 +21,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kbx_oipi_eu_plrcko.stan
+++ b/inst/models/b_Kbx_oipi_eu_plrcko.stan
@@ -10,7 +10,7 @@ data {
   real<lower=0> ER_daily_sigma;
   
   // Parameters of hierarchical priors on K600_daily (binned_sdfixed model)
-  int <lower=1> b; # number of K600_lnQ_nodes
+  int <lower=1> b; // number of K600_lnQ_nodes
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
@@ -21,10 +21,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kbx_oipi_tr_plrckm.stan
+++ b/inst/models/b_Kbx_oipi_tr_plrckm.stan
@@ -10,7 +10,7 @@ data {
   real<lower=0> ER_daily_sigma;
   
   // Parameters of hierarchical priors on K600_daily (binned_sdfixed model)
-  int <lower=1> b; # number of K600_lnQ_nodes
+  int <lower=1> b; // number of K600_lnQ_nodes
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
@@ -21,10 +21,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kbx_oipi_tr_plrcko.stan
+++ b/inst/models/b_Kbx_oipi_tr_plrcko.stan
@@ -10,7 +10,7 @@ data {
   real<lower=0> ER_daily_sigma;
   
   // Parameters of hierarchical priors on K600_daily (binned_sdfixed model)
-  int <lower=1> b; # number of K600_lnQ_nodes
+  int <lower=1> b; // number of K600_lnQ_nodes
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
@@ -21,10 +21,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kbx_pi_eu_plrckm.stan
+++ b/inst/models/b_Kbx_pi_eu_plrckm.stan
@@ -10,7 +10,7 @@ data {
   real<lower=0> ER_daily_sigma;
   
   // Parameters of hierarchical priors on K600_daily (binned_sdfixed model)
-  int <lower=1> b; # number of K600_lnQ_nodes
+  int <lower=1> b; // number of K600_lnQ_nodes
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kbx_pi_eu_plrcko.stan
+++ b/inst/models/b_Kbx_pi_eu_plrcko.stan
@@ -10,7 +10,7 @@ data {
   real<lower=0> ER_daily_sigma;
   
   // Parameters of hierarchical priors on K600_daily (binned_sdfixed model)
-  int <lower=1> b; # number of K600_lnQ_nodes
+  int <lower=1> b; // number of K600_lnQ_nodes
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kbx_pi_tr_plrckm.stan
+++ b/inst/models/b_Kbx_pi_tr_plrckm.stan
@@ -10,7 +10,7 @@ data {
   real<lower=0> ER_daily_sigma;
   
   // Parameters of hierarchical priors on K600_daily (binned_sdfixed model)
-  int <lower=1> b; # number of K600_lnQ_nodes
+  int <lower=1> b; // number of K600_lnQ_nodes
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kbx_pi_tr_plrcko.stan
+++ b/inst/models/b_Kbx_pi_tr_plrcko.stan
@@ -10,7 +10,7 @@ data {
   real<lower=0> ER_daily_sigma;
   
   // Parameters of hierarchical priors on K600_daily (binned_sdfixed model)
-  int <lower=1> b; # number of K600_lnQ_nodes
+  int <lower=1> b; // number of K600_lnQ_nodes
   real K600_lnQ_nodediffs_sdlog;
   vector[b] K600_lnQ_nodes_meanlog;
   vector[b] K600_lnQ_nodes_sdlog;
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kl0_oi_eu_plrckm.stan
+++ b/inst/models/b_Kl0_oi_eu_plrckm.stan
@@ -19,10 +19,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kl0_oi_eu_plrcko.stan
+++ b/inst/models/b_Kl0_oi_eu_plrcko.stan
@@ -19,10 +19,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kl0_oi_tr_plrckm.stan
+++ b/inst/models/b_Kl0_oi_tr_plrckm.stan
@@ -19,10 +19,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kl0_oi_tr_plrcko.stan
+++ b/inst/models/b_Kl0_oi_tr_plrcko.stan
@@ -19,10 +19,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kl0_oipi_eu_plrckm.stan
+++ b/inst/models/b_Kl0_oipi_eu_plrckm.stan
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kl0_oipi_eu_plrcko.stan
+++ b/inst/models/b_Kl0_oipi_eu_plrcko.stan
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kl0_oipi_tr_plrckm.stan
+++ b/inst/models/b_Kl0_oipi_tr_plrckm.stan
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kl0_oipi_tr_plrcko.stan
+++ b/inst/models/b_Kl0_oipi_tr_plrcko.stan
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kl0_pi_eu_plrckm.stan
+++ b/inst/models/b_Kl0_pi_eu_plrckm.stan
@@ -19,10 +19,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kl0_pi_eu_plrcko.stan
+++ b/inst/models/b_Kl0_pi_eu_plrcko.stan
@@ -19,10 +19,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kl0_pi_tr_plrckm.stan
+++ b/inst/models/b_Kl0_pi_tr_plrckm.stan
@@ -19,10 +19,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kl0_pi_tr_plrcko.stan
+++ b/inst/models/b_Kl0_pi_tr_plrcko.stan
@@ -19,10 +19,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kl_oi_eu_plrckm.stan
+++ b/inst/models/b_Kl_oi_eu_plrckm.stan
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kl_oi_eu_plrcko.stan
+++ b/inst/models/b_Kl_oi_eu_plrcko.stan
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kl_oi_tr_plrckm.stan
+++ b/inst/models/b_Kl_oi_tr_plrckm.stan
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kl_oi_tr_plrcko.stan
+++ b/inst/models/b_Kl_oi_tr_plrcko.stan
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kl_oipi_eu_plrckm.stan
+++ b/inst/models/b_Kl_oipi_eu_plrckm.stan
@@ -21,10 +21,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kl_oipi_eu_plrcko.stan
+++ b/inst/models/b_Kl_oipi_eu_plrcko.stan
@@ -21,10 +21,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kl_oipi_tr_plrckm.stan
+++ b/inst/models/b_Kl_oipi_tr_plrckm.stan
@@ -21,10 +21,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kl_oipi_tr_plrcko.stan
+++ b/inst/models/b_Kl_oipi_tr_plrcko.stan
@@ -21,10 +21,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kl_pi_eu_plrckm.stan
+++ b/inst/models/b_Kl_pi_eu_plrckm.stan
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kl_pi_eu_plrcko.stan
+++ b/inst/models/b_Kl_pi_eu_plrcko.stan
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kl_pi_tr_plrckm.stan
+++ b/inst/models/b_Kl_pi_tr_plrckm.stan
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kl_pi_tr_plrcko.stan
+++ b/inst/models/b_Kl_pi_tr_plrcko.stan
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Klx_oi_eu_plrckm.stan
+++ b/inst/models/b_Klx_oi_eu_plrckm.stan
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Klx_oi_eu_plrcko.stan
+++ b/inst/models/b_Klx_oi_eu_plrcko.stan
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Klx_oi_tr_plrckm.stan
+++ b/inst/models/b_Klx_oi_tr_plrckm.stan
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Klx_oi_tr_plrcko.stan
+++ b/inst/models/b_Klx_oi_tr_plrcko.stan
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Klx_oipi_eu_plrckm.stan
+++ b/inst/models/b_Klx_oipi_eu_plrckm.stan
@@ -21,10 +21,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Klx_oipi_eu_plrcko.stan
+++ b/inst/models/b_Klx_oipi_eu_plrcko.stan
@@ -21,10 +21,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Klx_oipi_tr_plrckm.stan
+++ b/inst/models/b_Klx_oipi_tr_plrckm.stan
@@ -21,10 +21,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Klx_oipi_tr_plrcko.stan
+++ b/inst/models/b_Klx_oipi_tr_plrcko.stan
@@ -21,10 +21,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Klx_pi_eu_plrckm.stan
+++ b/inst/models/b_Klx_pi_eu_plrckm.stan
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Klx_pi_eu_plrcko.stan
+++ b/inst/models/b_Klx_pi_eu_plrcko.stan
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Klx_pi_tr_plrckm.stan
+++ b/inst/models/b_Klx_pi_tr_plrckm.stan
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Klx_pi_tr_plrcko.stan
+++ b/inst/models/b_Klx_pi_tr_plrcko.stan
@@ -20,10 +20,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kn0_oi_eu_plrckm.stan
+++ b/inst/models/b_Kn0_oi_eu_plrckm.stan
@@ -17,10 +17,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kn0_oi_eu_plrcko.stan
+++ b/inst/models/b_Kn0_oi_eu_plrcko.stan
@@ -17,10 +17,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kn0_oi_tr_plrckm.stan
+++ b/inst/models/b_Kn0_oi_tr_plrckm.stan
@@ -17,10 +17,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kn0_oi_tr_plrcko.stan
+++ b/inst/models/b_Kn0_oi_tr_plrcko.stan
@@ -17,10 +17,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kn0_oipi_eu_plrckm.stan
+++ b/inst/models/b_Kn0_oipi_eu_plrckm.stan
@@ -18,10 +18,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kn0_oipi_eu_plrcko.stan
+++ b/inst/models/b_Kn0_oipi_eu_plrcko.stan
@@ -18,10 +18,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kn0_oipi_tr_plrckm.stan
+++ b/inst/models/b_Kn0_oipi_tr_plrckm.stan
@@ -18,10 +18,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kn0_oipi_tr_plrcko.stan
+++ b/inst/models/b_Kn0_oipi_tr_plrcko.stan
@@ -18,10 +18,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kn0_pi_eu_plrckm.stan
+++ b/inst/models/b_Kn0_pi_eu_plrckm.stan
@@ -17,10 +17,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kn0_pi_eu_plrcko.stan
+++ b/inst/models/b_Kn0_pi_eu_plrcko.stan
@@ -17,10 +17,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kn0_pi_tr_plrckm.stan
+++ b/inst/models/b_Kn0_pi_tr_plrckm.stan
@@ -17,10 +17,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kn0_pi_tr_plrcko.stan
+++ b/inst/models/b_Kn0_pi_tr_plrcko.stan
@@ -17,10 +17,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kn_oi_eu_plrckm.stan
+++ b/inst/models/b_Kn_oi_eu_plrckm.stan
@@ -18,10 +18,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kn_oi_eu_plrcko.stan
+++ b/inst/models/b_Kn_oi_eu_plrcko.stan
@@ -18,10 +18,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kn_oi_tr_plrckm.stan
+++ b/inst/models/b_Kn_oi_tr_plrckm.stan
@@ -18,10 +18,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kn_oi_tr_plrcko.stan
+++ b/inst/models/b_Kn_oi_tr_plrcko.stan
@@ -18,10 +18,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kn_oipi_eu_plrckm.stan
+++ b/inst/models/b_Kn_oipi_eu_plrckm.stan
@@ -19,10 +19,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kn_oipi_eu_plrcko.stan
+++ b/inst/models/b_Kn_oipi_eu_plrcko.stan
@@ -19,10 +19,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kn_oipi_tr_plrckm.stan
+++ b/inst/models/b_Kn_oipi_tr_plrckm.stan
@@ -19,10 +19,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kn_oipi_tr_plrcko.stan
+++ b/inst/models/b_Kn_oipi_tr_plrcko.stan
@@ -19,10 +19,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kn_pi_eu_plrckm.stan
+++ b/inst/models/b_Kn_pi_eu_plrckm.stan
@@ -18,10 +18,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kn_pi_eu_plrcko.stan
+++ b/inst/models/b_Kn_pi_eu_plrcko.stan
@@ -18,10 +18,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kn_pi_tr_plrckm.stan
+++ b/inst/models/b_Kn_pi_tr_plrckm.stan
@@ -18,10 +18,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Kn_pi_tr_plrcko.stan
+++ b/inst/models/b_Kn_pi_tr_plrcko.stan
@@ -18,10 +18,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Knx_oi_eu_plrckm.stan
+++ b/inst/models/b_Knx_oi_eu_plrckm.stan
@@ -18,10 +18,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Knx_oi_eu_plrcko.stan
+++ b/inst/models/b_Knx_oi_eu_plrcko.stan
@@ -18,10 +18,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Knx_oi_tr_plrckm.stan
+++ b/inst/models/b_Knx_oi_tr_plrckm.stan
@@ -18,10 +18,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Knx_oi_tr_plrcko.stan
+++ b/inst/models/b_Knx_oi_tr_plrcko.stan
@@ -18,10 +18,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Knx_oipi_eu_plrckm.stan
+++ b/inst/models/b_Knx_oipi_eu_plrckm.stan
@@ -19,10 +19,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Knx_oipi_eu_plrcko.stan
+++ b/inst/models/b_Knx_oipi_eu_plrcko.stan
@@ -19,10 +19,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Knx_oipi_tr_plrckm.stan
+++ b/inst/models/b_Knx_oipi_tr_plrckm.stan
@@ -19,10 +19,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Knx_oipi_tr_plrcko.stan
+++ b/inst/models/b_Knx_oipi_tr_plrcko.stan
@@ -19,10 +19,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Knx_pi_eu_plrckm.stan
+++ b/inst/models/b_Knx_pi_eu_plrckm.stan
@@ -18,10 +18,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Knx_pi_eu_plrcko.stan
+++ b/inst/models/b_Knx_pi_eu_plrcko.stan
@@ -18,10 +18,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Knx_pi_tr_plrckm.stan
+++ b/inst/models/b_Knx_pi_tr_plrckm.stan
@@ -18,10 +18,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_Knx_pi_tr_plrcko.stan
+++ b/inst/models/b_Knx_pi_tr_plrcko.stan
@@ -18,10 +18,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_np_oi_eu_plrckm.stan
+++ b/inst/models/b_np_oi_eu_plrckm.stan
@@ -15,10 +15,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_np_oi_eu_plrcko.stan
+++ b/inst/models/b_np_oi_eu_plrcko.stan
@@ -15,10 +15,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_np_oi_tr_plrckm.stan
+++ b/inst/models/b_np_oi_tr_plrckm.stan
@@ -15,10 +15,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_np_oi_tr_plrcko.stan
+++ b/inst/models/b_np_oi_tr_plrcko.stan
@@ -15,10 +15,10 @@ data {
   real<lower=0> err_obs_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_np_oipi_eu_plrckm.stan
+++ b/inst/models/b_np_oipi_eu_plrckm.stan
@@ -16,10 +16,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_np_oipi_eu_plrcko.stan
+++ b/inst/models/b_np_oipi_eu_plrcko.stan
@@ -16,10 +16,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_np_oipi_tr_plrckm.stan
+++ b/inst/models/b_np_oipi_tr_plrckm.stan
@@ -16,10 +16,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_np_oipi_tr_plrcko.stan
+++ b/inst/models/b_np_oipi_tr_plrcko.stan
@@ -16,10 +16,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_np_pi_eu_plrckm.stan
+++ b/inst/models/b_np_pi_eu_plrckm.stan
@@ -15,10 +15,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_np_pi_eu_plrcko.stan
+++ b/inst/models/b_np_pi_eu_plrcko.stan
@@ -15,10 +15,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_np_pi_tr_plrckm.stan
+++ b/inst/models/b_np_pi_tr_plrckm.stan
@@ -15,10 +15,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;

--- a/inst/models/b_np_pi_tr_plrcko.stan
+++ b/inst/models/b_np_pi_tr_plrcko.stan
@@ -15,10 +15,10 @@ data {
   real<lower=0> err_proc_iid_sigma_scale;
   
   // Data dimensions
-  int<lower=1> d; # number of dates
-  real<lower=0> timestep; # length of each timestep in days
-  int<lower=1> n24; # number of observations in first 24 hours per date
-  int<lower=1> n; # number of observations per date
+  int<lower=1> d; // number of dates
+  real<lower=0> timestep; // length of each timestep in days
+  int<lower=1> n24; // number of observations in first 24 hours per date
+  int<lower=1> n; // number of observations per date
   
   // Daily data
   vector[d] DO_obs_1;


### PR DESCRIPTION
* include dates in inst predictions
* take out # from stan files (now deprecated by stan in favor of \\)
* tell travis to wait longer on coveralls

