### PR TITLE
bugfix for the light modelers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: streamMetabolizer
 Type: Package
 Title: Models for Estimating Aquatic Photosynthesis and Respiration
-Version: 0.10.6
-Date: 2017-08-01
+Version: 0.10.7
+Date: 2017-09-01
 Author: Alison P. Appling, Robert O. Hall, Maite Arroita, and Charles B.
     Yackulic
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# 0.10.7
+
+* non-standard parameters from custom Bayesian models are now sorted in a less
+bewildering order in the model fit (as from `get_fit()`)
+
 # 0.10.4
 
 * `plot_DO_preds` with dygraphs works again, and now you can subset dates using


### PR DESCRIPTION
the custom param `coef_GPP` was getting sorted so that its indices started at [6,3] instead of [1,1] in `fit`. the logic for this case in previous versions of the code is a mystery to me - no idea what i was thinking - so i've replaced it with the assumption that things with two indices can parse those indices as [time,date].