### PR TITLE
KO2 conv warnings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: streamMetabolizer
 Type: Package
 Title: Models for Estimating Aquatic Photosynthesis and Respiration
-Version: 0.10.8
-Date: 2017-10-13
+Version: 0.10.9
+Date: 2018-01-25
 Author: Alison P. Appling, Robert O. Hall, Maite Arroita, and Charles B.
     Yackulic
 Authors@R: c(

--- a/R/convert_k600_to_kGAS.R
+++ b/R/convert_k600_to_kGAS.R
@@ -20,6 +20,12 @@ convert_k600_to_kGAS = function(k600, temperature, gas="O2") {
   # suppressing "In getSchmidt(temperature, gas) : temperature out of range" b/c it's way too common
   out <- suppressWarnings(LakeMetabolizer::k600.2.kGAS.base(v(k600), v(temperature), v(gas)))
   
+  # catch extreme values of temperature or kGAS that are so wild they're making NaNs
+  bad_nans <- which(!is.na(k600) & !is.na(temperature) & is.nan(out))
+  if(length(bad_nans) > 0) {
+    warning('one or more k600 or temperature values are extreme, causing NaNs in the k600-kGAS conversion')
+  }
+  
   if(with_units) u(out, get_units(k600)) else out
 }
 
@@ -44,5 +50,12 @@ convert_kGAS_to_k600 = function(kGAS, temperature, gas="O2") {
   
   # suppressing "In getSchmidt(temperature, gas) : temperature out of range" b/c it's way too common
   conversion <- 1/suppressWarnings(LakeMetabolizer::k600.2.kGAS.base(1, v(temperature), v(gas)))
+  
+  # catch extreme values of temperature or kGAS that are so wild they're making NaNs
+  bad_nans <- which(!is.na(temperature) & is.nan(conversion))
+  if(length(bad_nans) > 0) {
+    warning('one or more temperature values are extreme, causing NaNs in the kGAS-k600 conversion')
+  }
+  
   kGAS * conversion # do the conversion and adopt the units of kGAS, if any
 }

--- a/R/metab_mle.R
+++ b/R/metab_mle.R
@@ -154,9 +154,15 @@ mle_1ply <- function(
     # create the series of nested functions to compute the negative log 
     # likelihood (NLL) for a trio of values for GPP.daily, ER.daily, and
     # K600.daily
-    dDOdt <- create_calc_dDOdt(
-      data_ply, ode_method=features$ode_method, GPP_fun=features$GPP_fun,
-      ER_fun=features$ER_fun, deficit_src=features$deficit_src)
+    dDOdt <- withCallingHandlers({
+      create_calc_dDOdt(
+        data_ply, ode_method=features$ode_method, GPP_fun=features$GPP_fun,
+        ER_fun=features$ER_fun, deficit_src=features$deficit_src)
+    }, warning=function(war) {
+      # on warning: record the warning and run nlm again
+      warn_strs <<- c(warn_strs, war$message)
+      invokeRestart("muffleWarning")
+    })
     DO <- create_calc_DO(dDOdt)
     # to fit DO.mod.1, err_obs_iid_sigma, and/or err_proc_iid_sigma, add these
     # to par.names in create_calc_NLL and nlm.args$p. to fix them, pass them as


### PR DESCRIPTION
Better KO2-K600 conversion warnings/errors for MLE and Bayesian models. Inspired by a query from Alice when this was giving errors:
```
mm <- metab(revise(specs('b_Kb_oipi_tr_plrckm.stan'), burnin_steps=100, saved_steps=100), data=fitdata)
# Error in FUN(X[[i]], ...) : 
#   Stan does not support NA (in KO2_conv) in data
# failed to preprocess the data; sampling not done
# Warning message:
# In metab_fun(specs = specs, data = data, data_daily = data_daily,  :
#   Modeling failed
#   Warnings:
#     Stan model 'b_Kb_oipi_tr_plrckm' does not contain samples.
```
where fitdata turned out to have one row where temp.water was 72 (really high) and the conversion factor was coming out as NaN.

Now for MLE there's a warning added to the fit:
```
> mm <- metab(specs('mle'), data=shortdat)
> mm@fit %>% filter(warnings != '')
        date GPP.daily GPP.daily.sd GPP.daily.grad ER.daily ER.daily.sd ER.daily.grad K600.daily K600.daily.sd K600.daily.grad minimum
1 2013-08-08        NA           NA             NA       NA          NA            NA         NA            NA              NA      NA
  iterations code code.str
1         NA   NA     <NA>
                                                                                                          warnings
1 NaNs in KO2-K600 conversion at 2013-08-09 01:10:42 (temp.water=72.98); NA/Inf replaced by maximum positive value
                                                        errors
1 Lapack routine dgesv: system is exactly singular: U[1,1] = 0
```

and for Bayes there's an error during data prep:
```
> mm <- metab(revise(specs('b_Kb_oipi_tr_plrckm.stan'), burnin_steps=100, saved_steps=100), data=shortdat)
Warning message:
In metab_fun(specs = specs, data = data, data_daily = data_daily,  :
  Modeling failed
  Errors:
    NaNs in KO2-K600 conversion at 2013-08-09 01:10:42 (temp.water=72.98)
```