### PR TITLE
Maintenance/remotes and context cleanup

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,7 +57,7 @@ Suggests:
     xts,
     rmarkdown
 Remotes:
-    github::appling/unitted
+    github::mdodrill-usgs/unitted@fix/select-defunct
 Collate:
     '01-onLoad.R'
     'calc_DO_deficit.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,7 +57,7 @@ Suggests:
     xts,
     rmarkdown
 Remotes:
-    github::mdodrill-usgs/unitted@fix/select-defunct
+    github::appling/unitted
 Collate:
     '01-onLoad.R'
     'calc_DO_deficit.R'

--- a/tests/testthat/test-calc_DO.R
+++ b/tests/testthat/test-calc_DO.R
@@ -1,4 +1,3 @@
-context("calc_DO")
 
 library(unitted)
 

--- a/tests/testthat/test-calc_depth.R
+++ b/tests/testthat/test-calc_depth.R
@@ -1,4 +1,3 @@
-context("calc_depth")
 
 test_that("calc_depth checks & returns values & units as expected", {
   # basic numbers, with & without defaults

--- a/tests/testthat/test-calc_light.R
+++ b/tests/testthat/test-calc_light.R
@@ -1,4 +1,3 @@
-context("calc_light")
 
 test_that("high-level light function works", {
   stimes <- lubridate::force_tz(as.POSIXct(sprintf('2016-09-27 %02d:00', 1:24)), 'UTC')

--- a/tests/testthat/test-convert.R
+++ b/tests/testthat/test-convert.R
@@ -1,4 +1,3 @@
-context("convert")
 
 test_that("converting between k600 and kgas works", {
   # k600 to kgas

--- a/tests/testthat/test-distribs.R
+++ b/tests/testthat/test-distribs.R
@@ -1,4 +1,3 @@
-context('distribs')
 # this file is really just to help me wrap my head around parameter
 # distributions and parameter scaling.
 

--- a/tests/testthat/test-french.R
+++ b/tests/testthat/test-french.R
@@ -1,4 +1,3 @@
-context("french creek data")
 
 test_that("French Creek data are similar for streamMetabolizer & Bob Hall's code", {
 

--- a/tests/testthat/test-get_params.R
+++ b/tests/testthat/test-get_params.R
@@ -1,4 +1,3 @@
-context('get_params')
 
 dat <- data_metab('3','15')
 mm <- metab_mle(specs("m_np_oi_tr_plrckm.nlm"), data=dat)

--- a/tests/testthat/test-hierarchy.R
+++ b/tests/testthat/test-hierarchy.R
@@ -1,4 +1,3 @@
-context("hierarchy")
 
 ## There are currently no automated tests here because everything is slow.
 ## Longer tests, where we can investigate parameter estimates & convergence, are

--- a/tests/testthat/test-metab-class.R
+++ b/tests/testthat/test-metab-class.R
@@ -1,4 +1,3 @@
-context("metab_model class and inheriting classes")
 
 test_that("metab_model objects can be created and accessed", {
   

--- a/tests/testthat/test-metab_Kmodel.R
+++ b/tests/testthat/test-metab_Kmodel.R
@@ -1,4 +1,3 @@
-context("metab_Kmodel")
 
 library(dplyr)
 

--- a/tests/testthat/test-metab_bayes.R
+++ b/tests/testthat/test-metab_bayes.R
@@ -1,4 +1,3 @@
-context("metab_bayes")
 
 # # NB: these lines work within testthat() calls:
 # skip()

--- a/tests/testthat/test-metab_helpers.R
+++ b/tests/testthat/test-metab_helpers.R
@@ -1,4 +1,3 @@
-context("metab_model_helpers")
 
 test_that("mm_data works", {
 

--- a/tests/testthat/test-metab_mle.R
+++ b/tests/testthat/test-metab_mle.R
@@ -1,4 +1,3 @@
-context("metab_mle")
 
 test_that("metab_mle models can be created", {
 

--- a/tests/testthat/test-metab_night.R
+++ b/tests/testthat/test-metab_night.R
@@ -1,4 +1,3 @@
-context("metab_night")
 
 test_that("metab_night models can be created", {
   

--- a/tests/testthat/test-metab_sim.R
+++ b/tests/testthat/test-metab_sim.R
@@ -1,4 +1,3 @@
-context("metab_sim")
 
 test_that("metab_sim predictions (predict_metab, predict_DO) make sense", {
 

--- a/tests/testthat/test-mm_name.R
+++ b/tests/testthat/test-mm_name.R
@@ -1,4 +1,3 @@
-context('mm_name')
 
 test_that("mm_name can generate names", {
   # missing args OK

--- a/tests/testthat/test-model_by_ply.R
+++ b/tests/testthat/test-model_by_ply.R
@@ -1,4 +1,3 @@
-context("model_by_ply")
 
 test_that("mm_model_by_ply creates intuitive ply_dates from day_start and day_end", {
   

--- a/tests/testthat/test-predict.R
+++ b/tests/testthat/test-predict.R
@@ -1,4 +1,3 @@
-context('predict')
 
 test_that('predict_DO works as expected', {
   


### PR DESCRIPTION
Small cleanup PR: pins `Remotes:` to my `unitted` fork (pending upstream merge - see `unitted` PR) and removed deprecated `context()` calls from all 18 test files (non-operational in testthat 3.x). Test suite is clean, 390 passed, 4 pre-existing, 0 fail, 0 warn. Alison is out this week, happy to wait for review, just flagging it's ready whenever is convenient. Planning to keep stacking related cleanup work on top in the meantime. 