### PR TITLE
Replace dplyr::do() with group_modify() in plot functions

### DIFF
--- a/R/plot_DO_preds.R
+++ b/R/plot_DO_preds.R
@@ -117,9 +117,9 @@ plot_DO_preds <- function(
         filter(as %in% y_var) %>%
         arrange(solar.time) %>%
         group_by(date) %>%
-        do(., {
-          out <- .[c(seq_len(nrow(.)),nrow(.)),]
-          out[nrow(.)+1,c('pure','mod','obs')] <- NA
+        group_modify(~ {
+          out <- .x[c(seq_len(nrow(.x)), nrow(.x)), ]
+          out[nrow(.x)+1, c('pure','mod','obs')] <- NA
           out
         }) %>%
         ungroup()

--- a/R/plot_metab_preds.R
+++ b/R/plot_metab_preds.R
@@ -55,7 +55,7 @@ plot_metab_preds <- function(metab_preds, y_var=c('GPP','ER'),
       preds_ggplot <- v(metab_preds_all) %>%
         filter(as %in% y_var) %>%
         group_by(as) %>%
-        do({ if(all(is.na(.$fit))) .[FALSE,] else . }) %>%
+        group_modify(~ if(all(is.na(.x$fit))) .x[FALSE,] else .x) %>%
         ungroup()
       if('GPP' %in% names(y_lim)) {
         lim <- y_lim[['GPP']][1]; if(!is.na(lim)) preds_ggplot <- filter(preds_ggplot, as != 'GPP' | is.na(fit) | fit >= lim)

--- a/tests/testthat/test-plot_DO_preds.R
+++ b/tests/testthat/test-plot_DO_preds.R
@@ -1,0 +1,47 @@
+
+test_that("plot_DO_preds runs with style='dygraphs' without error", {
+  skip_if_not_installed("dygraphs")
+  skip_if_not_installed("xts")
+
+  mm <- metab_night(specs(mm_name('night')), data=data_metab('3', day_start=12, day_end=36))
+  DO_preds <- predict_DO(mm)
+  result <- plot_DO_preds(DO_preds, style='dygraphs', y_var='conc')
+
+  expect_s3_class(result, "dygraphs")
+})
+
+test_that("dygraphs gap-row logic inserts one NA sentinel row per date group", {
+  # Verifies the group_modify() replacement for do() in plot_DO_preds.R.
+  # The transformation appends a NA-padded copy of each group's last row to
+  # create a visual break between dates in dygraphs output.
+  mm <- metab_night(specs(mm_name('night')), data=data_metab('3', day_start=12, day_end=36))
+  DO_preds <- predict_DO(mm)
+
+  # Build the conc subset of preds_xts_input — same structure as inside plot_DO_preds()
+  input <- unitted::v(DO_preds) %>%
+    mutate(as='conc', pure=NA, mod=DO.mod, obs=DO.obs) %>%
+    arrange(solar.time)
+
+  n_dates <- length(unique(input$date))  # 3 with data_metab('3')
+
+  result <- input %>%
+    group_by(date) %>%
+    group_modify(~ {
+      out <- .x[c(seq_len(nrow(.x)), nrow(.x)), ]
+      out[nrow(.x)+1, c('pure','mod','obs')] <- NA
+      out
+    }) %>%
+    ungroup()
+
+  # Exactly one sentinel appended per date group
+  expect_equal(nrow(result), nrow(input) + n_dates)
+
+  # All key columns survive the transformation
+  expect_true(all(c('date', 'solar.time', 'pure', 'mod', 'obs', 'as') %in% names(result)))
+
+  # The last row of each date group is the NA sentinel
+  sentinels <- result %>% group_by(date) %>% slice_tail(n=1) %>% ungroup()
+  expect_equal(nrow(sentinels), n_dates)
+  expect_true(all(is.na(sentinels$mod)))
+  expect_true(all(is.na(sentinels$obs)))
+})

--- a/tests/testthat/test-plot_metab_preds.R
+++ b/tests/testthat/test-plot_metab_preds.R
@@ -1,0 +1,35 @@
+
+test_that("plot_metab_preds retains all groups when fit data are present", {
+  mm <- metab_night(specs(mm_name('night')), data=data_metab('3', day_start=12, day_end=36))
+  g <- plot_metab_preds(mm)
+
+  expect_s3_class(g, "ggplot")
+
+  preds <- g$data
+  # Column presence checked with %in% rather than exact order — group_modify()
+  # moves the grouping key to first position, unlike the old do() code.
+  expect_true(all(c('date', 'as', 'fit', 'lwr', 'upr', 'var') %in% names(preds)))
+
+  # 3 dates × 2 groups (GPP, ER) = 6 rows; both groups retained
+  expect_equal(nrow(preds), 6)
+  expect_setequal(unique(preds$as), c('GPP', 'ER'))
+})
+
+test_that("plot_metab_preds drops groups where all fit values are NA", {
+  # Verifies the group_modify() replacement for do() in plot_metab_preds.R.
+  # plot_metab_preds() accepts a predict_metab() data frame directly.
+  mm <- metab_night(specs(mm_name('night')), data=data_metab('3', day_start=12, day_end=36))
+  mp <- predict_metab(mm)
+
+  # Force GPP to all-NA so the GPP group should be dropped
+  mp_no_gpp <- mp
+  mp_no_gpp$GPP <- NA_real_
+
+  g <- plot_metab_preds(mp_no_gpp)
+  preds <- g$data
+
+  # GPP group dropped; only ER rows remain (3 dates)
+  expect_false('GPP' %in% unique(preds$as))
+  expect_true('ER' %in% unique(preds$as))
+  expect_equal(nrow(preds), 3)
+})


### PR DESCRIPTION
## Description

Stacked on #454 

`dplyr::do()` was removed in dplyr 1.1. Replaced both call sites with `group_modify()` (preferred over `reframe()` here, since both functions return the same column shape as input — just filtered/augmented rows — which is exactly what `group_modify()` is for; `reframe()` is meant for summary-style operations).

### Site 1: `plot_DO_preds.R:120` (dygraphs path)

Logic unchanged: duplicates the last row of each date group and sets `pure`/`mod`/`obs` to `NA` on the new row, creating a visual gap between date segments in dygraphs.

### Site 2: `plot_metab_preds.R:58`

Logic unchanged: drops a group entirely if all `fit` values are `NA`, otherwise passes it through.

### Verification

Captured reference output (structure, columns, row counts, values) before changing either site, then diffed after:

- **`plot_DO_preds.R`**: row count, column names, column order, and all values — identical.
- **`plot_metab_preds.R`**: row count and values identical. Column order differs by one — `group_modify()` moves the grouping key (`as`) from position 11 to position 1. This is documented `group_modify()` behavior, not a bug. No functional impact: all downstream usage (ggplot2 aesthetics, `filter()` calls) accesses columns by name, not position. Flagging here in case anyone relies on positional column access elsewhere (e.g. writing to CSV and inspecting column order directly).

### Test coverage

Neither function had direct test coverage before this change (flagged in the original package audit as a pre-existing gap). Added tests for both:

- `test-plot_DO_preds.R`: covers the dygraphs gap-row transformation logic. The full end-to-end dygraphs test skips in this environment since the `dygraphs` package isn't installed, but the transformation logic itself is covered independently.
- `test-plot_metab_preds.R`: covers both the normal case (groups retained) and the all-NA case (group dropped). Assertions check column presence via `%in%` rather than exact position, since this PR introduces the column-order change noted above.

Full suite: **402 pass, 5 skip, 0 fail, 0 warn** (baseline was 390/4/0/0 — the +12 pass / +1 skip is exactly the new tests added here; nothing else changed).
