### PR TITLE
Modernize Stan array declaration syntax (postfix -> prefix array[])

### DIFF
--- a/R/mm_generate_mcmc_file.R
+++ b/R/mm_generate_mcmc_file.R
@@ -203,28 +203,28 @@ mm_generate_mcmc_file <- function(
           linear=c(
             'vector[d] lnQ_daily;'),
           binned=c(
-            'int<lower=1,upper=b> lnQ_bins[2,d];',
-            'vector<lower=0,upper=1>[d] lnQ_bin_weights[2];')
+            'array[2, d] int<lower=1, upper=b> lnQ_bins;',
+            'array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;')
         )),
       
       # prepare to iterate over n obs for all d at a time:
       # https://groups.google.com/forum/#!topic/stan-users/ZHeFFV4q_gk
       indent(
         comment('Data'),
-        'vector[d] DO_obs[n];',
-        'vector[d] DO_sat[n];',
+        'array[n] vector[d] DO_obs;',
+        'array[n] vector[d] DO_sat;',
         # light_mult_GPP and const_mult_ER are multipliers that reflect light
         # and a constant, respectively, and produce estimates of GPP and ER,
         # respectively. The resulting GPP and ER estimates are in per-day units
         # (not per-timestep units)
         switch(
           features$GPP_fun,
-          linlight='vector[d] light_mult_GPP[n];',
-          satlight='vector[d] light[n];'
+          linlight='array[n] vector[d] light_mult_GPP;',
+          satlight='array[n] vector[d] light;'
         ),
-        'vector[d] const_mult_ER[n];',
-        'vector[d] depth[n];',
-        'vector[d] KO2_conv[n];'),
+        'array[n] vector[d] const_mult_ER;',
+        'array[n] vector[d] depth;',
+        'array[n] vector[d] KO2_conv;'),
       
       '}',''
     ),
@@ -290,16 +290,16 @@ mm_generate_mcmc_file <- function(
           # need to figure out how to scale phi (which might be 0-1 or very close to 0)
           'real<lower=0, upper=1> err_proc_acor_phi;',
           'real<lower=0> err_proc_acor_sigma_scaled;',
-          sprintf('vector[d] err_proc_acor_inc[%s];', switch(ode_method, euler='n-1', trapezoid='n'))),
+          sprintf('array[%s] vector[d] err_proc_acor_inc;', switch(ode_method, euler='n-1', trapezoid='n'))),
         if(err_proc_iid) c(
           'real<lower=0> err_proc_iid_sigma_scaled;'),
         if(err_proc_GPP) c(
           'real<lower=0> err_mult_GPP_sdlog_scaled;',
-          'vector<lower=0>[d] err_mult_GPP[n];'),
+          'array[n] vector<lower=0>[d] err_mult_GPP;'),
         
         # DO_mod if it's a fitted parameter (oipi models)
         if(err_obs_iid && err_proc_iid) c(
-          'vector[d] DO_mod[n];')
+          'array[n] vector[d] DO_mod;')
         
       ),
       '}',''
@@ -327,7 +327,7 @@ mm_generate_mcmc_file <- function(
       if(err_obs_iid) c(
         'real<lower=0> err_obs_iid_sigma;'),
       if(err_proc_acor || err_proc_iid) c(
-        'vector[d] DO_mod_partial_sigma[n];'
+        'array[n] vector[d] DO_mod_partial_sigma;'
       ),
       if(err_proc_acor) c(
         # 'real<lower=0, upper=1> err_proc_acor_phi;', # currently opting not to scale phi (which might be 0-1 or very close to 0)
@@ -343,25 +343,25 @@ mm_generate_mcmc_file <- function(
       
       # instantaneous GPP, ER, and KO2. the nth value isn't used to calculate DO
       # when ode_method=euler, but it's always used to calculate GPP and ER
-      c('vector[d] GPP_inst[n];',
-        'vector[d] ER_inst[n];',
-        'vector[d] KO2_inst[n];'),
+      c('array[n] vector[d] GPP_inst;',
+        'array[n] vector[d] ER_inst;',
+        'array[n] vector[d] KO2_inst;'),
       
       # these variables contain the combined, unnormalized GPP-producing
       # multiplier (combo_mult_GPP) and the sum of those multipliers on each day
       # (sum_combo_mult_GPP), from which the final GPP multiplier (mult_GPP)
       # will be implicitly calculated in the GPP_inst equation
       if(err_proc_GPP) c(
-        'vector<lower=0>[d] combo_mult_GPP[n];',
+        'array[n] vector<lower=0>[d] combo_mult_GPP;',
         'vector<lower=0>[d] mean_combo_mult_GPP;'),
       
       # instantaneous DO and possibly process error values
       if(err_proc_iid)
-        'vector[d] DO_mod_partial[n];'
+        'array[n] vector[d] DO_mod_partial;'
       else # err_obs_iid and/or err_proc_acor without err_proc_iid
-        'vector[d] DO_mod[n];',
+        'array[n] vector[d] DO_mod;',
       if(err_proc_acor)
-        sprintf('vector[d] err_proc_acor[%s];', switch(ode_method, euler='n-1', trapezoid='n'))
+        sprintf('array[%s] vector[d] err_proc_acor;', switch(ode_method, euler='n-1', trapezoid='n'))
     ),
     
     # pooling parameters
@@ -557,7 +557,7 @@ mm_generate_mcmc_file <- function(
                   s('timestep ./ depth[i,j]')
                 ),
                 'trapezoid' = indent(
-                  'sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*',
+                  'sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*',
                   switch(
                     deficit_src,
                     'DO_obs' = s('(timestep / 2.0)'),
@@ -685,11 +685,11 @@ mm_generate_mcmc_file <- function(
     'generated quantities {',
     
     chunk(
-      if(err_obs_iid) 'vector[d] err_obs_iid[n];',
-      if(err_proc_iid) 'vector[d] err_proc_iid[n-1];',
+      if(err_obs_iid) 'array[n] vector[d] err_obs_iid;',
+      if(err_proc_iid) 'array[n-1] vector[d] err_proc_iid;',
       if(err_proc_GPP) c(
-        'vector[d] GPP_inst_partial[n];',
-        'vector[d] err_proc_GPP[n];',
+        'array[n] vector[d] GPP_inst_partial;',
+        'array[n] vector[d] err_proc_GPP;',
         'int n_light_day; // temporary',
         'vector[n] GPP_inst_day; // temporary',
         'vector[n] GPP_inst_diff_day; // temporary',

--- a/inst/models/b_Kb0_oi_eu_plrckm.stan
+++ b/inst/models/b_Kb0_oi_eu_plrckm.stan
@@ -26,16 +26,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -51,10 +51,10 @@ transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -107,7 +107,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kb0_oi_eu_plrcko.stan
+++ b/inst/models/b_Kb0_oi_eu_plrcko.stan
@@ -26,16 +26,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -51,10 +51,10 @@ transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -107,7 +107,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kb0_oi_eu_psrckm.stan
+++ b/inst/models/b_Kb0_oi_eu_psrckm.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -54,10 +54,10 @@ transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -114,7 +114,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kb0_oi_eu_psrcko.stan
+++ b/inst/models/b_Kb0_oi_eu_psrcko.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -54,10 +54,10 @@ transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -114,7 +114,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kb0_oi_tr_plrckm.stan
+++ b/inst/models/b_Kb0_oi_tr_plrckm.stan
@@ -26,16 +26,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -51,10 +51,10 @@ transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -109,7 +109,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kb0_oi_tr_plrcko.stan
+++ b/inst/models/b_Kb0_oi_tr_plrcko.stan
@@ -26,16 +26,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -51,10 +51,10 @@ transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -109,7 +109,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kb0_oi_tr_psrckm.stan
+++ b/inst/models/b_Kb0_oi_tr_psrckm.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -54,10 +54,10 @@ transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -116,7 +116,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kb0_oi_tr_psrcko.stan
+++ b/inst/models/b_Kb0_oi_tr_psrcko.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -54,10 +54,10 @@ transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -116,7 +116,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kb0_oipi_eu_plrckm.stan
+++ b/inst/models/b_Kb0_oipi_eu_plrckm.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,19 +47,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -125,8 +125,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kb0_oipi_eu_plrcko.stan
+++ b/inst/models/b_Kb0_oipi_eu_plrcko.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,19 +47,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -125,8 +125,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kb0_oipi_eu_psrckm.stan
+++ b/inst/models/b_Kb0_oipi_eu_psrckm.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,20 +49,20 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -132,8 +132,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kb0_oipi_eu_psrcko.stan
+++ b/inst/models/b_Kb0_oipi_eu_psrcko.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,20 +49,20 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -132,8 +132,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kb0_oipi_tr_plrckm.stan
+++ b/inst/models/b_Kb0_oipi_tr_plrckm.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,19 +47,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -96,7 +96,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -128,8 +128,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kb0_oipi_tr_plrcko.stan
+++ b/inst/models/b_Kb0_oipi_tr_plrcko.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,19 +47,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -96,7 +96,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -128,8 +128,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kb0_oipi_tr_psrckm.stan
+++ b/inst/models/b_Kb0_oipi_tr_psrckm.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,20 +49,20 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -102,7 +102,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -135,8 +135,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kb0_oipi_tr_psrcko.stan
+++ b/inst/models/b_Kb0_oipi_tr_psrcko.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,20 +49,20 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -102,7 +102,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -135,8 +135,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kb0_oipipp_eu_plrckm.stan
+++ b/inst/models/b_Kb0_oipipp_eu_plrckm.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,23 +49,23 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -145,10 +145,10 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kb0_oipipp_eu_plrcko.stan
+++ b/inst/models/b_Kb0_oipipp_eu_plrcko.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,23 +49,23 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -145,10 +145,10 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kb0_oipipp_tr_plrckm.stan
+++ b/inst/models/b_Kb0_oipipp_tr_plrckm.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,23 +49,23 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -109,7 +109,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -148,10 +148,10 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kb0_oipipp_tr_plrcko.stan
+++ b/inst/models/b_Kb0_oipipp_tr_plrcko.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,23 +49,23 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -109,7 +109,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -148,10 +148,10 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kb0_oipp_eu_plrckm.stan
+++ b/inst/models/b_Kb0_oipp_eu_plrckm.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,7 +47,7 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
@@ -55,12 +55,12 @@ transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -127,9 +127,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kb0_oipp_eu_plrcko.stan
+++ b/inst/models/b_Kb0_oipp_eu_plrcko.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,7 +47,7 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
@@ -55,12 +55,12 @@ transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -127,9 +127,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kb0_oipp_tr_plrckm.stan
+++ b/inst/models/b_Kb0_oipp_tr_plrckm.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,7 +47,7 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
@@ -55,12 +55,12 @@ transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -129,9 +129,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kb0_oipp_tr_plrcko.stan
+++ b/inst/models/b_Kb0_oipp_tr_plrcko.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,7 +47,7 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
@@ -55,12 +55,12 @@ transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -129,9 +129,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kb0_pi_eu_plrckm.stan
+++ b/inst/models/b_Kb0_pi_eu_plrckm.stan
@@ -26,16 +26,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,12 +50,12 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -113,7 +113,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kb0_pi_eu_plrcko.stan
+++ b/inst/models/b_Kb0_pi_eu_plrcko.stan
@@ -26,16 +26,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,12 +50,12 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -113,7 +113,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kb0_pi_eu_psrckm.stan
+++ b/inst/models/b_Kb0_pi_eu_psrckm.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -52,13 +52,13 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -120,7 +120,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kb0_pi_eu_psrcko.stan
+++ b/inst/models/b_Kb0_pi_eu_psrcko.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -52,13 +52,13 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -120,7 +120,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kb0_pi_tr_plrckm.stan
+++ b/inst/models/b_Kb0_pi_tr_plrckm.stan
@@ -26,16 +26,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,12 +50,12 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -91,7 +91,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -116,7 +116,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kb0_pi_tr_plrcko.stan
+++ b/inst/models/b_Kb0_pi_tr_plrcko.stan
@@ -26,16 +26,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,12 +50,12 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -91,7 +91,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -116,7 +116,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kb0_pi_tr_psrckm.stan
+++ b/inst/models/b_Kb0_pi_tr_psrckm.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -52,13 +52,13 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -97,7 +97,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -123,7 +123,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kb0_pi_tr_psrcko.stan
+++ b/inst/models/b_Kb0_pi_tr_psrcko.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -52,13 +52,13 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -97,7 +97,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -123,7 +123,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kb0_pipp_eu_plrckm.stan
+++ b/inst/models/b_Kb0_pipp_eu_plrckm.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,21 +47,21 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -133,9 +133,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kb0_pipp_eu_plrcko.stan
+++ b/inst/models/b_Kb0_pipp_eu_plrcko.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,21 +47,21 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -133,9 +133,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kb0_pipp_tr_plrckm.stan
+++ b/inst/models/b_Kb0_pipp_tr_plrckm.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,21 +47,21 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -104,7 +104,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -136,9 +136,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kb0_pipp_tr_plrcko.stan
+++ b/inst/models/b_Kb0_pipp_tr_plrcko.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,21 +47,21 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -104,7 +104,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -136,9 +136,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kb0_pp_eu_plrckm.stan
+++ b/inst/models/b_Kb0_pp_eu_plrckm.stan
@@ -26,16 +26,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -45,19 +45,19 @@ parameters {
   vector[b] lnK600_lnQ_nodes;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_mult_GPP_sdlog = err_mult_GPP_sdlog_sigma * err_mult_GPP_sdlog_scaled;
@@ -115,8 +115,8 @@ model {
   
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kb0_pp_eu_plrcko.stan
+++ b/inst/models/b_Kb0_pp_eu_plrcko.stan
@@ -26,16 +26,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -45,19 +45,19 @@ parameters {
   vector[b] lnK600_lnQ_nodes;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_mult_GPP_sdlog = err_mult_GPP_sdlog_sigma * err_mult_GPP_sdlog_scaled;
@@ -115,8 +115,8 @@ model {
   
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kb0_pp_tr_plrckm.stan
+++ b/inst/models/b_Kb0_pp_tr_plrckm.stan
@@ -26,16 +26,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -45,19 +45,19 @@ parameters {
   vector[b] lnK600_lnQ_nodes;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_mult_GPP_sdlog = err_mult_GPP_sdlog_sigma * err_mult_GPP_sdlog_scaled;
@@ -117,8 +117,8 @@ model {
   
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kb0_pp_tr_plrcko.stan
+++ b/inst/models/b_Kb0_pp_tr_plrcko.stan
@@ -26,16 +26,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -45,19 +45,19 @@ parameters {
   vector[b] lnK600_lnQ_nodes;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_mult_GPP_sdlog = err_mult_GPP_sdlog_sigma * err_mult_GPP_sdlog_scaled;
@@ -117,8 +117,8 @@ model {
   
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kb_oi_eu_plrckm.stan
+++ b/inst/models/b_Kb_oi_eu_plrckm.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -54,10 +54,10 @@ transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -114,7 +114,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kb_oi_eu_plrcko.stan
+++ b/inst/models/b_Kb_oi_eu_plrcko.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -54,10 +54,10 @@ transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -114,7 +114,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kb_oi_eu_psrckm.stan
+++ b/inst/models/b_Kb_oi_eu_psrckm.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -57,10 +57,10 @@ transformed parameters {
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -121,7 +121,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kb_oi_eu_psrcko.stan
+++ b/inst/models/b_Kb_oi_eu_psrcko.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -57,10 +57,10 @@ transformed parameters {
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -121,7 +121,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kb_oi_tr_plrckm.stan
+++ b/inst/models/b_Kb_oi_tr_plrckm.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -54,10 +54,10 @@ transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -116,7 +116,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kb_oi_tr_plrcko.stan
+++ b/inst/models/b_Kb_oi_tr_plrcko.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -54,10 +54,10 @@ transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -116,7 +116,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kb_oi_tr_psrckm.stan
+++ b/inst/models/b_Kb_oi_tr_psrckm.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -57,10 +57,10 @@ transformed parameters {
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -123,7 +123,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kb_oi_tr_psrcko.stan
+++ b/inst/models/b_Kb_oi_tr_psrcko.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -57,10 +57,10 @@ transformed parameters {
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -123,7 +123,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kb_oipi_eu_plrckm.stan
+++ b/inst/models/b_Kb_oipi_eu_plrckm.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,19 +50,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -132,8 +132,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kb_oipi_eu_plrcko.stan
+++ b/inst/models/b_Kb_oipi_eu_plrcko.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,19 +50,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -132,8 +132,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kb_oipi_eu_psrckm.stan
+++ b/inst/models/b_Kb_oipi_eu_psrckm.stan
@@ -29,16 +29,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -52,20 +52,20 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -139,8 +139,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kb_oipi_eu_psrcko.stan
+++ b/inst/models/b_Kb_oipi_eu_psrcko.stan
@@ -29,16 +29,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -52,20 +52,20 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -139,8 +139,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kb_oipi_tr_plrckm.stan
+++ b/inst/models/b_Kb_oipi_tr_plrckm.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,19 +50,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -101,7 +101,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -135,8 +135,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kb_oipi_tr_plrcko.stan
+++ b/inst/models/b_Kb_oipi_tr_plrcko.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,19 +50,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -101,7 +101,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -135,8 +135,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kb_oipi_tr_psrckm.stan
+++ b/inst/models/b_Kb_oipi_tr_psrckm.stan
@@ -29,16 +29,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -52,20 +52,20 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -107,7 +107,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -142,8 +142,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kb_oipi_tr_psrcko.stan
+++ b/inst/models/b_Kb_oipi_tr_psrcko.stan
@@ -29,16 +29,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -52,20 +52,20 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -107,7 +107,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -142,8 +142,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kb_oipipp_eu_plrckm.stan
+++ b/inst/models/b_Kb_oipipp_eu_plrckm.stan
@@ -29,16 +29,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -52,23 +52,23 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -152,10 +152,10 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kb_oipipp_eu_plrcko.stan
+++ b/inst/models/b_Kb_oipipp_eu_plrcko.stan
@@ -29,16 +29,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -52,23 +52,23 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -152,10 +152,10 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kb_oipipp_tr_plrckm.stan
+++ b/inst/models/b_Kb_oipipp_tr_plrckm.stan
@@ -29,16 +29,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -52,23 +52,23 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -114,7 +114,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -155,10 +155,10 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kb_oipipp_tr_plrcko.stan
+++ b/inst/models/b_Kb_oipipp_tr_plrcko.stan
@@ -29,16 +29,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -52,23 +52,23 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -114,7 +114,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -155,10 +155,10 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kb_oipp_eu_plrckm.stan
+++ b/inst/models/b_Kb_oipp_eu_plrckm.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,7 +50,7 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
@@ -58,12 +58,12 @@ transformed parameters {
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -134,9 +134,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kb_oipp_eu_plrcko.stan
+++ b/inst/models/b_Kb_oipp_eu_plrcko.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,7 +50,7 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
@@ -58,12 +58,12 @@ transformed parameters {
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -134,9 +134,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kb_oipp_tr_plrckm.stan
+++ b/inst/models/b_Kb_oipp_tr_plrckm.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,7 +50,7 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
@@ -58,12 +58,12 @@ transformed parameters {
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -136,9 +136,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kb_oipp_tr_plrcko.stan
+++ b/inst/models/b_Kb_oipp_tr_plrcko.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,7 +50,7 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
@@ -58,12 +58,12 @@ transformed parameters {
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -136,9 +136,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kb_pi_eu_plrckm.stan
+++ b/inst/models/b_Kb_pi_eu_plrckm.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -53,12 +53,12 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -120,7 +120,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kb_pi_eu_plrcko.stan
+++ b/inst/models/b_Kb_pi_eu_plrcko.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -53,12 +53,12 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -120,7 +120,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kb_pi_eu_psrckm.stan
+++ b/inst/models/b_Kb_pi_eu_psrckm.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -55,13 +55,13 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -127,7 +127,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kb_pi_eu_psrcko.stan
+++ b/inst/models/b_Kb_pi_eu_psrcko.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -55,13 +55,13 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -127,7 +127,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kb_pi_tr_plrckm.stan
+++ b/inst/models/b_Kb_pi_tr_plrckm.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -53,12 +53,12 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -96,7 +96,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -123,7 +123,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kb_pi_tr_plrcko.stan
+++ b/inst/models/b_Kb_pi_tr_plrcko.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -53,12 +53,12 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -96,7 +96,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -123,7 +123,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kb_pi_tr_psrckm.stan
+++ b/inst/models/b_Kb_pi_tr_psrckm.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -55,13 +55,13 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -102,7 +102,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -130,7 +130,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kb_pi_tr_psrcko.stan
+++ b/inst/models/b_Kb_pi_tr_psrcko.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -55,13 +55,13 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -102,7 +102,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -130,7 +130,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kb_pipp_eu_plrckm.stan
+++ b/inst/models/b_Kb_pipp_eu_plrckm.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,21 +50,21 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -140,9 +140,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kb_pipp_eu_plrcko.stan
+++ b/inst/models/b_Kb_pipp_eu_plrcko.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,21 +50,21 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -140,9 +140,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kb_pipp_tr_plrckm.stan
+++ b/inst/models/b_Kb_pipp_tr_plrckm.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,21 +50,21 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -109,7 +109,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -143,9 +143,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kb_pipp_tr_plrcko.stan
+++ b/inst/models/b_Kb_pipp_tr_plrcko.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,21 +50,21 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -109,7 +109,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -143,9 +143,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kb_pp_eu_plrckm.stan
+++ b/inst/models/b_Kb_pp_eu_plrckm.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -48,19 +48,19 @@ parameters {
   real<lower=0> K600_daily_sigma_scaled;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -122,8 +122,8 @@ model {
   
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kb_pp_eu_plrcko.stan
+++ b/inst/models/b_Kb_pp_eu_plrcko.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -48,19 +48,19 @@ parameters {
   real<lower=0> K600_daily_sigma_scaled;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -122,8 +122,8 @@ model {
   
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kb_pp_tr_plrckm.stan
+++ b/inst/models/b_Kb_pp_tr_plrckm.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -48,19 +48,19 @@ parameters {
   real<lower=0> K600_daily_sigma_scaled;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -124,8 +124,8 @@ model {
   
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kb_pp_tr_plrcko.stan
+++ b/inst/models/b_Kb_pp_tr_plrcko.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -48,19 +48,19 @@ parameters {
   real<lower=0> K600_daily_sigma_scaled;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -124,8 +124,8 @@ model {
   
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kbx_oi_eu_plrckm.stan
+++ b/inst/models/b_Kbx_oi_eu_plrckm.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -52,10 +52,10 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -108,7 +108,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kbx_oi_eu_plrcko.stan
+++ b/inst/models/b_Kbx_oi_eu_plrcko.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -52,10 +52,10 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -108,7 +108,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kbx_oi_eu_psrckm.stan
+++ b/inst/models/b_Kbx_oi_eu_psrckm.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -55,10 +55,10 @@ transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -115,7 +115,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kbx_oi_eu_psrcko.stan
+++ b/inst/models/b_Kbx_oi_eu_psrcko.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -55,10 +55,10 @@ transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -115,7 +115,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kbx_oi_tr_plrckm.stan
+++ b/inst/models/b_Kbx_oi_tr_plrckm.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -52,10 +52,10 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -110,7 +110,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kbx_oi_tr_plrcko.stan
+++ b/inst/models/b_Kbx_oi_tr_plrcko.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -52,10 +52,10 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -110,7 +110,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kbx_oi_tr_psrckm.stan
+++ b/inst/models/b_Kbx_oi_tr_psrckm.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -55,10 +55,10 @@ transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -117,7 +117,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kbx_oi_tr_psrcko.stan
+++ b/inst/models/b_Kbx_oi_tr_psrcko.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -55,10 +55,10 @@ transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -117,7 +117,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kbx_oipi_eu_plrckm.stan
+++ b/inst/models/b_Kbx_oipi_eu_plrckm.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,18 +49,18 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -126,8 +126,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kbx_oipi_eu_plrcko.stan
+++ b/inst/models/b_Kbx_oipi_eu_plrcko.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,18 +49,18 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -126,8 +126,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kbx_oipi_eu_psrckm.stan
+++ b/inst/models/b_Kbx_oipi_eu_psrckm.stan
@@ -29,16 +29,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -51,19 +51,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -133,8 +133,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kbx_oipi_eu_psrcko.stan
+++ b/inst/models/b_Kbx_oipi_eu_psrcko.stan
@@ -29,16 +29,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -51,19 +51,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -133,8 +133,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kbx_oipi_tr_plrckm.stan
+++ b/inst/models/b_Kbx_oipi_tr_plrckm.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,18 +49,18 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -96,7 +96,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -129,8 +129,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kbx_oipi_tr_plrcko.stan
+++ b/inst/models/b_Kbx_oipi_tr_plrcko.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,18 +49,18 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -96,7 +96,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -129,8 +129,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kbx_oipi_tr_psrckm.stan
+++ b/inst/models/b_Kbx_oipi_tr_psrckm.stan
@@ -29,16 +29,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -51,19 +51,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -102,7 +102,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -136,8 +136,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kbx_oipi_tr_psrcko.stan
+++ b/inst/models/b_Kbx_oipi_tr_psrcko.stan
@@ -29,16 +29,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -51,19 +51,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -102,7 +102,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -136,8 +136,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kbx_oipipp_eu_plrckm.stan
+++ b/inst/models/b_Kbx_oipipp_eu_plrckm.stan
@@ -29,16 +29,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -51,22 +51,22 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -146,10 +146,10 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kbx_oipipp_eu_plrcko.stan
+++ b/inst/models/b_Kbx_oipipp_eu_plrcko.stan
@@ -29,16 +29,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -51,22 +51,22 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -146,10 +146,10 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kbx_oipipp_tr_plrckm.stan
+++ b/inst/models/b_Kbx_oipipp_tr_plrckm.stan
@@ -29,16 +29,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -51,22 +51,22 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -109,7 +109,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -149,10 +149,10 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kbx_oipipp_tr_plrcko.stan
+++ b/inst/models/b_Kbx_oipipp_tr_plrcko.stan
@@ -29,16 +29,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -51,22 +51,22 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -109,7 +109,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -149,10 +149,10 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kbx_oipp_eu_plrckm.stan
+++ b/inst/models/b_Kbx_oipp_eu_plrckm.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,19 +49,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -128,9 +128,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kbx_oipp_eu_plrcko.stan
+++ b/inst/models/b_Kbx_oipp_eu_plrcko.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,19 +49,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -128,9 +128,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kbx_oipp_tr_plrckm.stan
+++ b/inst/models/b_Kbx_oipp_tr_plrckm.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,19 +49,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -130,9 +130,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kbx_oipp_tr_plrcko.stan
+++ b/inst/models/b_Kbx_oipp_tr_plrcko.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,19 +49,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -130,9 +130,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kbx_pi_eu_plrckm.stan
+++ b/inst/models/b_Kbx_pi_eu_plrckm.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -51,12 +51,12 @@ parameters {
 
 transformed parameters {
   vector[d] K600_daily_predlog;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -114,7 +114,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kbx_pi_eu_plrcko.stan
+++ b/inst/models/b_Kbx_pi_eu_plrcko.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -51,12 +51,12 @@ parameters {
 
 transformed parameters {
   vector[d] K600_daily_predlog;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -114,7 +114,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kbx_pi_eu_psrckm.stan
+++ b/inst/models/b_Kbx_pi_eu_psrckm.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -53,13 +53,13 @@ parameters {
 
 transformed parameters {
   vector[d] K600_daily_predlog;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -121,7 +121,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kbx_pi_eu_psrcko.stan
+++ b/inst/models/b_Kbx_pi_eu_psrcko.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -53,13 +53,13 @@ parameters {
 
 transformed parameters {
   vector[d] K600_daily_predlog;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -121,7 +121,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kbx_pi_tr_plrckm.stan
+++ b/inst/models/b_Kbx_pi_tr_plrckm.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -51,12 +51,12 @@ parameters {
 
 transformed parameters {
   vector[d] K600_daily_predlog;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -91,7 +91,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -117,7 +117,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kbx_pi_tr_plrcko.stan
+++ b/inst/models/b_Kbx_pi_tr_plrcko.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -51,12 +51,12 @@ parameters {
 
 transformed parameters {
   vector[d] K600_daily_predlog;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -91,7 +91,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -117,7 +117,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kbx_pi_tr_psrckm.stan
+++ b/inst/models/b_Kbx_pi_tr_psrckm.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -53,13 +53,13 @@ parameters {
 
 transformed parameters {
   vector[d] K600_daily_predlog;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -97,7 +97,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -124,7 +124,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kbx_pi_tr_psrcko.stan
+++ b/inst/models/b_Kbx_pi_tr_psrcko.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -53,13 +53,13 @@ parameters {
 
 transformed parameters {
   vector[d] K600_daily_predlog;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -97,7 +97,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -124,7 +124,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kbx_pipp_eu_plrckm.stan
+++ b/inst/models/b_Kbx_pipp_eu_plrckm.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,20 +49,20 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -134,9 +134,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kbx_pipp_eu_plrcko.stan
+++ b/inst/models/b_Kbx_pipp_eu_plrcko.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,20 +49,20 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -134,9 +134,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kbx_pipp_tr_plrckm.stan
+++ b/inst/models/b_Kbx_pipp_tr_plrckm.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,20 +49,20 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -104,7 +104,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -137,9 +137,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kbx_pipp_tr_plrcko.stan
+++ b/inst/models/b_Kbx_pipp_tr_plrcko.stan
@@ -28,16 +28,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,20 +49,20 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -104,7 +104,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -137,9 +137,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kbx_pp_eu_plrckm.stan
+++ b/inst/models/b_Kbx_pp_eu_plrckm.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,18 +47,18 @@ parameters {
   vector[b] lnK600_lnQ_nodes;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_mult_GPP_sdlog = err_mult_GPP_sdlog_sigma * err_mult_GPP_sdlog_scaled;
@@ -116,8 +116,8 @@ model {
   
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kbx_pp_eu_plrcko.stan
+++ b/inst/models/b_Kbx_pp_eu_plrcko.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,18 +47,18 @@ parameters {
   vector[b] lnK600_lnQ_nodes;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_mult_GPP_sdlog = err_mult_GPP_sdlog_sigma * err_mult_GPP_sdlog_scaled;
@@ -116,8 +116,8 @@ model {
   
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kbx_pp_tr_plrckm.stan
+++ b/inst/models/b_Kbx_pp_tr_plrckm.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,18 +47,18 @@ parameters {
   vector[b] lnK600_lnQ_nodes;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_mult_GPP_sdlog = err_mult_GPP_sdlog_sigma * err_mult_GPP_sdlog_scaled;
@@ -118,8 +118,8 @@ model {
   
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kbx_pp_tr_plrcko.stan
+++ b/inst/models/b_Kbx_pp_tr_plrcko.stan
@@ -27,16 +27,16 @@ data {
   
   // Daily data
   vector[d] DO_obs_1;
-  int<lower=1,upper=b> lnQ_bins[2,d];
-  vector<lower=0,upper=1>[d] lnQ_bin_weights[2];
+  array[2, d] int<lower=1, upper=b> lnQ_bins;
+  array[2] vector<lower=0, upper=1>[d] lnQ_bin_weights;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,18 +47,18 @@ parameters {
   vector[b] lnK600_lnQ_nodes;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_mult_GPP_sdlog = err_mult_GPP_sdlog_sigma * err_mult_GPP_sdlog_scaled;
@@ -118,8 +118,8 @@ model {
   
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kl0_oi_eu_plrckm.stan
+++ b/inst/models/b_Kl0_oi_eu_plrckm.stan
@@ -29,12 +29,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -51,10 +51,10 @@ transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -104,7 +104,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kl0_oi_eu_plrcko.stan
+++ b/inst/models/b_Kl0_oi_eu_plrcko.stan
@@ -29,12 +29,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -51,10 +51,10 @@ transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -104,7 +104,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kl0_oi_eu_psrckm.stan
+++ b/inst/models/b_Kl0_oi_eu_psrckm.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -54,10 +54,10 @@ transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -111,7 +111,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kl0_oi_eu_psrcko.stan
+++ b/inst/models/b_Kl0_oi_eu_psrcko.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -54,10 +54,10 @@ transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -111,7 +111,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kl0_oi_tr_plrckm.stan
+++ b/inst/models/b_Kl0_oi_tr_plrckm.stan
@@ -29,12 +29,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -51,10 +51,10 @@ transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -106,7 +106,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kl0_oi_tr_plrcko.stan
+++ b/inst/models/b_Kl0_oi_tr_plrcko.stan
@@ -29,12 +29,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -51,10 +51,10 @@ transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -106,7 +106,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kl0_oi_tr_psrckm.stan
+++ b/inst/models/b_Kl0_oi_tr_psrckm.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -54,10 +54,10 @@ transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -113,7 +113,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kl0_oi_tr_psrcko.stan
+++ b/inst/models/b_Kl0_oi_tr_psrcko.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -54,10 +54,10 @@ transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -113,7 +113,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kl0_oipi_eu_plrckm.stan
+++ b/inst/models/b_Kl0_oipi_eu_plrckm.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,19 +47,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -122,8 +122,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kl0_oipi_eu_plrcko.stan
+++ b/inst/models/b_Kl0_oipi_eu_plrcko.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,19 +47,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -122,8 +122,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kl0_oipi_eu_psrckm.stan
+++ b/inst/models/b_Kl0_oipi_eu_psrckm.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,20 +49,20 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -129,8 +129,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kl0_oipi_eu_psrcko.stan
+++ b/inst/models/b_Kl0_oipi_eu_psrcko.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,20 +49,20 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -129,8 +129,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kl0_oipi_tr_plrckm.stan
+++ b/inst/models/b_Kl0_oipi_tr_plrckm.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,19 +47,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -95,7 +95,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -125,8 +125,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kl0_oipi_tr_plrcko.stan
+++ b/inst/models/b_Kl0_oipi_tr_plrcko.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,19 +47,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -95,7 +95,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -125,8 +125,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kl0_oipi_tr_psrckm.stan
+++ b/inst/models/b_Kl0_oipi_tr_psrckm.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,20 +49,20 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -101,7 +101,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -132,8 +132,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kl0_oipi_tr_psrcko.stan
+++ b/inst/models/b_Kl0_oipi_tr_psrcko.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,20 +49,20 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -101,7 +101,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -132,8 +132,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kl0_oipipp_eu_plrckm.stan
+++ b/inst/models/b_Kl0_oipipp_eu_plrckm.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,23 +49,23 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -142,10 +142,10 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kl0_oipipp_eu_plrcko.stan
+++ b/inst/models/b_Kl0_oipipp_eu_plrcko.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,23 +49,23 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -142,10 +142,10 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kl0_oipipp_tr_plrckm.stan
+++ b/inst/models/b_Kl0_oipipp_tr_plrckm.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,23 +49,23 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -108,7 +108,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -145,10 +145,10 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kl0_oipipp_tr_plrcko.stan
+++ b/inst/models/b_Kl0_oipipp_tr_plrcko.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,23 +49,23 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -108,7 +108,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -145,10 +145,10 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kl0_oipp_eu_plrckm.stan
+++ b/inst/models/b_Kl0_oipp_eu_plrckm.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,7 +47,7 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
@@ -55,12 +55,12 @@ transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -124,9 +124,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kl0_oipp_eu_plrcko.stan
+++ b/inst/models/b_Kl0_oipp_eu_plrcko.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,7 +47,7 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
@@ -55,12 +55,12 @@ transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -124,9 +124,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kl0_oipp_tr_plrckm.stan
+++ b/inst/models/b_Kl0_oipp_tr_plrckm.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,7 +47,7 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
@@ -55,12 +55,12 @@ transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -126,9 +126,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kl0_oipp_tr_plrcko.stan
+++ b/inst/models/b_Kl0_oipp_tr_plrcko.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,7 +47,7 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
@@ -55,12 +55,12 @@ transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -126,9 +126,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kl0_pi_eu_plrckm.stan
+++ b/inst/models/b_Kl0_pi_eu_plrckm.stan
@@ -29,12 +29,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,12 +50,12 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -110,7 +110,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kl0_pi_eu_plrcko.stan
+++ b/inst/models/b_Kl0_pi_eu_plrcko.stan
@@ -29,12 +29,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,12 +50,12 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -110,7 +110,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kl0_pi_eu_psrckm.stan
+++ b/inst/models/b_Kl0_pi_eu_psrckm.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -52,13 +52,13 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -117,7 +117,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kl0_pi_eu_psrcko.stan
+++ b/inst/models/b_Kl0_pi_eu_psrcko.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -52,13 +52,13 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -117,7 +117,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kl0_pi_tr_plrckm.stan
+++ b/inst/models/b_Kl0_pi_tr_plrckm.stan
@@ -29,12 +29,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,12 +50,12 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -90,7 +90,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -113,7 +113,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kl0_pi_tr_plrcko.stan
+++ b/inst/models/b_Kl0_pi_tr_plrcko.stan
@@ -29,12 +29,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,12 +50,12 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -90,7 +90,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -113,7 +113,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kl0_pi_tr_psrckm.stan
+++ b/inst/models/b_Kl0_pi_tr_psrckm.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -52,13 +52,13 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -96,7 +96,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -120,7 +120,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kl0_pi_tr_psrcko.stan
+++ b/inst/models/b_Kl0_pi_tr_psrcko.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -52,13 +52,13 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -96,7 +96,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -120,7 +120,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kl0_pipp_eu_plrckm.stan
+++ b/inst/models/b_Kl0_pipp_eu_plrckm.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,21 +47,21 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -130,9 +130,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kl0_pipp_eu_plrcko.stan
+++ b/inst/models/b_Kl0_pipp_eu_plrcko.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,21 +47,21 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -130,9 +130,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kl0_pipp_tr_plrckm.stan
+++ b/inst/models/b_Kl0_pipp_tr_plrckm.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,21 +47,21 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -103,7 +103,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -133,9 +133,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kl0_pipp_tr_plrcko.stan
+++ b/inst/models/b_Kl0_pipp_tr_plrcko.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,21 +47,21 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -103,7 +103,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -133,9 +133,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kl0_pp_eu_plrckm.stan
+++ b/inst/models/b_Kl0_pp_eu_plrckm.stan
@@ -29,12 +29,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -45,19 +45,19 @@ parameters {
   real lnK600_lnQ_slope;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_mult_GPP_sdlog = err_mult_GPP_sdlog_sigma * err_mult_GPP_sdlog_scaled;
@@ -112,8 +112,8 @@ model {
   
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kl0_pp_eu_plrcko.stan
+++ b/inst/models/b_Kl0_pp_eu_plrcko.stan
@@ -29,12 +29,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -45,19 +45,19 @@ parameters {
   real lnK600_lnQ_slope;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_mult_GPP_sdlog = err_mult_GPP_sdlog_sigma * err_mult_GPP_sdlog_scaled;
@@ -112,8 +112,8 @@ model {
   
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kl0_pp_tr_plrckm.stan
+++ b/inst/models/b_Kl0_pp_tr_plrckm.stan
@@ -29,12 +29,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -45,19 +45,19 @@ parameters {
   real lnK600_lnQ_slope;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_mult_GPP_sdlog = err_mult_GPP_sdlog_sigma * err_mult_GPP_sdlog_scaled;
@@ -114,8 +114,8 @@ model {
   
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kl0_pp_tr_plrcko.stan
+++ b/inst/models/b_Kl0_pp_tr_plrcko.stan
@@ -29,12 +29,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -45,19 +45,19 @@ parameters {
   real lnK600_lnQ_slope;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   vector[d] K600_daily;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_mult_GPP_sdlog = err_mult_GPP_sdlog_sigma * err_mult_GPP_sdlog_scaled;
@@ -114,8 +114,8 @@ model {
   
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kl_oi_eu_plrckm.stan
+++ b/inst/models/b_Kl_oi_eu_plrckm.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -54,10 +54,10 @@ transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -111,7 +111,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kl_oi_eu_plrcko.stan
+++ b/inst/models/b_Kl_oi_eu_plrcko.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -54,10 +54,10 @@ transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -111,7 +111,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kl_oi_eu_psrckm.stan
+++ b/inst/models/b_Kl_oi_eu_psrckm.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -57,10 +57,10 @@ transformed parameters {
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -118,7 +118,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kl_oi_eu_psrcko.stan
+++ b/inst/models/b_Kl_oi_eu_psrcko.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -57,10 +57,10 @@ transformed parameters {
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -118,7 +118,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kl_oi_tr_plrckm.stan
+++ b/inst/models/b_Kl_oi_tr_plrckm.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -54,10 +54,10 @@ transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -113,7 +113,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kl_oi_tr_plrcko.stan
+++ b/inst/models/b_Kl_oi_tr_plrcko.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -54,10 +54,10 @@ transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -113,7 +113,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kl_oi_tr_psrckm.stan
+++ b/inst/models/b_Kl_oi_tr_psrckm.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -57,10 +57,10 @@ transformed parameters {
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -120,7 +120,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kl_oi_tr_psrcko.stan
+++ b/inst/models/b_Kl_oi_tr_psrcko.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -57,10 +57,10 @@ transformed parameters {
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -120,7 +120,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kl_oipi_eu_plrckm.stan
+++ b/inst/models/b_Kl_oipi_eu_plrckm.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,19 +50,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -129,8 +129,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kl_oipi_eu_plrcko.stan
+++ b/inst/models/b_Kl_oipi_eu_plrcko.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,19 +50,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -129,8 +129,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kl_oipi_eu_psrckm.stan
+++ b/inst/models/b_Kl_oipi_eu_psrckm.stan
@@ -32,12 +32,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -52,20 +52,20 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -136,8 +136,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kl_oipi_eu_psrcko.stan
+++ b/inst/models/b_Kl_oipi_eu_psrcko.stan
@@ -32,12 +32,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -52,20 +52,20 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -136,8 +136,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kl_oipi_tr_plrckm.stan
+++ b/inst/models/b_Kl_oipi_tr_plrckm.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,19 +50,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -100,7 +100,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -132,8 +132,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kl_oipi_tr_plrcko.stan
+++ b/inst/models/b_Kl_oipi_tr_plrcko.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,19 +50,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -100,7 +100,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -132,8 +132,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kl_oipi_tr_psrckm.stan
+++ b/inst/models/b_Kl_oipi_tr_psrckm.stan
@@ -32,12 +32,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -52,20 +52,20 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -106,7 +106,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -139,8 +139,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kl_oipi_tr_psrcko.stan
+++ b/inst/models/b_Kl_oipi_tr_psrcko.stan
@@ -32,12 +32,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -52,20 +52,20 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -106,7 +106,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -139,8 +139,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kl_oipipp_eu_plrckm.stan
+++ b/inst/models/b_Kl_oipipp_eu_plrckm.stan
@@ -32,12 +32,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -52,23 +52,23 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -149,10 +149,10 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kl_oipipp_eu_plrcko.stan
+++ b/inst/models/b_Kl_oipipp_eu_plrcko.stan
@@ -32,12 +32,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -52,23 +52,23 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -149,10 +149,10 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kl_oipipp_tr_plrckm.stan
+++ b/inst/models/b_Kl_oipipp_tr_plrckm.stan
@@ -32,12 +32,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -52,23 +52,23 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -113,7 +113,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -152,10 +152,10 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kl_oipipp_tr_plrcko.stan
+++ b/inst/models/b_Kl_oipipp_tr_plrcko.stan
@@ -32,12 +32,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -52,23 +52,23 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -113,7 +113,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -152,10 +152,10 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kl_oipp_eu_plrckm.stan
+++ b/inst/models/b_Kl_oipp_eu_plrckm.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,7 +50,7 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
@@ -58,12 +58,12 @@ transformed parameters {
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -131,9 +131,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kl_oipp_eu_plrcko.stan
+++ b/inst/models/b_Kl_oipp_eu_plrcko.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,7 +50,7 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
@@ -58,12 +58,12 @@ transformed parameters {
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -131,9 +131,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kl_oipp_tr_plrckm.stan
+++ b/inst/models/b_Kl_oipp_tr_plrckm.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,7 +50,7 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
@@ -58,12 +58,12 @@ transformed parameters {
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -133,9 +133,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kl_oipp_tr_plrcko.stan
+++ b/inst/models/b_Kl_oipp_tr_plrcko.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,7 +50,7 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
@@ -58,12 +58,12 @@ transformed parameters {
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -133,9 +133,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kl_pi_eu_plrckm.stan
+++ b/inst/models/b_Kl_pi_eu_plrckm.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -53,12 +53,12 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -117,7 +117,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kl_pi_eu_plrcko.stan
+++ b/inst/models/b_Kl_pi_eu_plrcko.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -53,12 +53,12 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -117,7 +117,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kl_pi_eu_psrckm.stan
+++ b/inst/models/b_Kl_pi_eu_psrckm.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -55,13 +55,13 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -124,7 +124,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kl_pi_eu_psrcko.stan
+++ b/inst/models/b_Kl_pi_eu_psrcko.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -55,13 +55,13 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -124,7 +124,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kl_pi_tr_plrckm.stan
+++ b/inst/models/b_Kl_pi_tr_plrckm.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -53,12 +53,12 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -95,7 +95,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -120,7 +120,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kl_pi_tr_plrcko.stan
+++ b/inst/models/b_Kl_pi_tr_plrcko.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -53,12 +53,12 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -95,7 +95,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -120,7 +120,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kl_pi_tr_psrckm.stan
+++ b/inst/models/b_Kl_pi_tr_psrckm.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -55,13 +55,13 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -101,7 +101,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -127,7 +127,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kl_pi_tr_psrcko.stan
+++ b/inst/models/b_Kl_pi_tr_psrcko.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -55,13 +55,13 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -101,7 +101,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -127,7 +127,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kl_pipp_eu_plrckm.stan
+++ b/inst/models/b_Kl_pipp_eu_plrckm.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,21 +50,21 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -137,9 +137,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kl_pipp_eu_plrcko.stan
+++ b/inst/models/b_Kl_pipp_eu_plrcko.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,21 +50,21 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -137,9 +137,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kl_pipp_tr_plrckm.stan
+++ b/inst/models/b_Kl_pipp_tr_plrckm.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,21 +50,21 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -108,7 +108,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -140,9 +140,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kl_pipp_tr_plrcko.stan
+++ b/inst/models/b_Kl_pipp_tr_plrcko.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,21 +50,21 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -108,7 +108,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -140,9 +140,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kl_pp_eu_plrckm.stan
+++ b/inst/models/b_Kl_pp_eu_plrckm.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -48,19 +48,19 @@ parameters {
   real<lower=0> K600_daily_sigma_scaled;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -119,8 +119,8 @@ model {
   
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kl_pp_eu_plrcko.stan
+++ b/inst/models/b_Kl_pp_eu_plrcko.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -48,19 +48,19 @@ parameters {
   real<lower=0> K600_daily_sigma_scaled;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -119,8 +119,8 @@ model {
   
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kl_pp_tr_plrckm.stan
+++ b/inst/models/b_Kl_pp_tr_plrckm.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -48,19 +48,19 @@ parameters {
   real<lower=0> K600_daily_sigma_scaled;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -121,8 +121,8 @@ model {
   
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kl_pp_tr_plrcko.stan
+++ b/inst/models/b_Kl_pp_tr_plrcko.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -48,19 +48,19 @@ parameters {
   real<lower=0> K600_daily_sigma_scaled;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> K600_daily_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sigma = K600_daily_sigma_sigma * K600_daily_sigma_scaled;
@@ -121,8 +121,8 @@ model {
   
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Klx_oi_eu_plrckm.stan
+++ b/inst/models/b_Klx_oi_eu_plrckm.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -52,10 +52,10 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -105,7 +105,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Klx_oi_eu_plrcko.stan
+++ b/inst/models/b_Klx_oi_eu_plrcko.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -52,10 +52,10 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -105,7 +105,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Klx_oi_eu_psrckm.stan
+++ b/inst/models/b_Klx_oi_eu_psrckm.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -55,10 +55,10 @@ transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -112,7 +112,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Klx_oi_eu_psrcko.stan
+++ b/inst/models/b_Klx_oi_eu_psrcko.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -55,10 +55,10 @@ transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -112,7 +112,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Klx_oi_tr_plrckm.stan
+++ b/inst/models/b_Klx_oi_tr_plrckm.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -52,10 +52,10 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -107,7 +107,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Klx_oi_tr_plrcko.stan
+++ b/inst/models/b_Klx_oi_tr_plrcko.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -52,10 +52,10 @@ parameters {
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -107,7 +107,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Klx_oi_tr_psrckm.stan
+++ b/inst/models/b_Klx_oi_tr_psrckm.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -55,10 +55,10 @@ transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -114,7 +114,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Klx_oi_tr_psrcko.stan
+++ b/inst/models/b_Klx_oi_tr_psrcko.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -55,10 +55,10 @@ transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -114,7 +114,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Klx_oipi_eu_plrckm.stan
+++ b/inst/models/b_Klx_oipi_eu_plrckm.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,18 +49,18 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -123,8 +123,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Klx_oipi_eu_plrcko.stan
+++ b/inst/models/b_Klx_oipi_eu_plrcko.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,18 +49,18 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -123,8 +123,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Klx_oipi_eu_psrckm.stan
+++ b/inst/models/b_Klx_oipi_eu_psrckm.stan
@@ -32,12 +32,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -51,19 +51,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -130,8 +130,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Klx_oipi_eu_psrcko.stan
+++ b/inst/models/b_Klx_oipi_eu_psrcko.stan
@@ -32,12 +32,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -51,19 +51,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -130,8 +130,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Klx_oipi_tr_plrckm.stan
+++ b/inst/models/b_Klx_oipi_tr_plrckm.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,18 +49,18 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -95,7 +95,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -126,8 +126,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Klx_oipi_tr_plrcko.stan
+++ b/inst/models/b_Klx_oipi_tr_plrcko.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,18 +49,18 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -95,7 +95,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -126,8 +126,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Klx_oipi_tr_psrckm.stan
+++ b/inst/models/b_Klx_oipi_tr_psrckm.stan
@@ -32,12 +32,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -51,19 +51,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -101,7 +101,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -133,8 +133,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Klx_oipi_tr_psrcko.stan
+++ b/inst/models/b_Klx_oipi_tr_psrcko.stan
@@ -32,12 +32,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -51,19 +51,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -101,7 +101,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -133,8 +133,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Klx_oipipp_eu_plrckm.stan
+++ b/inst/models/b_Klx_oipipp_eu_plrckm.stan
@@ -32,12 +32,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -51,22 +51,22 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -143,10 +143,10 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Klx_oipipp_eu_plrcko.stan
+++ b/inst/models/b_Klx_oipipp_eu_plrcko.stan
@@ -32,12 +32,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -51,22 +51,22 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -143,10 +143,10 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Klx_oipipp_tr_plrckm.stan
+++ b/inst/models/b_Klx_oipipp_tr_plrckm.stan
@@ -32,12 +32,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -51,22 +51,22 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -108,7 +108,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -146,10 +146,10 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Klx_oipipp_tr_plrcko.stan
+++ b/inst/models/b_Klx_oipipp_tr_plrcko.stan
@@ -32,12 +32,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -51,22 +51,22 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -108,7 +108,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -146,10 +146,10 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Klx_oipp_eu_plrckm.stan
+++ b/inst/models/b_Klx_oipp_eu_plrckm.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,19 +49,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -125,9 +125,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Klx_oipp_eu_plrcko.stan
+++ b/inst/models/b_Klx_oipp_eu_plrcko.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,19 +49,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -125,9 +125,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Klx_oipp_tr_plrckm.stan
+++ b/inst/models/b_Klx_oipp_tr_plrckm.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,19 +49,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -127,9 +127,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Klx_oipp_tr_plrcko.stan
+++ b/inst/models/b_Klx_oipp_tr_plrcko.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,19 +49,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -127,9 +127,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Klx_pi_eu_plrckm.stan
+++ b/inst/models/b_Klx_pi_eu_plrckm.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -51,12 +51,12 @@ parameters {
 
 transformed parameters {
   vector[d] K600_daily_predlog;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -111,7 +111,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Klx_pi_eu_plrcko.stan
+++ b/inst/models/b_Klx_pi_eu_plrcko.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -51,12 +51,12 @@ parameters {
 
 transformed parameters {
   vector[d] K600_daily_predlog;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -111,7 +111,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Klx_pi_eu_psrckm.stan
+++ b/inst/models/b_Klx_pi_eu_psrckm.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -53,13 +53,13 @@ parameters {
 
 transformed parameters {
   vector[d] K600_daily_predlog;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -118,7 +118,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Klx_pi_eu_psrcko.stan
+++ b/inst/models/b_Klx_pi_eu_psrcko.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -53,13 +53,13 @@ parameters {
 
 transformed parameters {
   vector[d] K600_daily_predlog;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -118,7 +118,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Klx_pi_tr_plrckm.stan
+++ b/inst/models/b_Klx_pi_tr_plrckm.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -51,12 +51,12 @@ parameters {
 
 transformed parameters {
   vector[d] K600_daily_predlog;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -90,7 +90,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -114,7 +114,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Klx_pi_tr_plrcko.stan
+++ b/inst/models/b_Klx_pi_tr_plrcko.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -51,12 +51,12 @@ parameters {
 
 transformed parameters {
   vector[d] K600_daily_predlog;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -90,7 +90,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -114,7 +114,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Klx_pi_tr_psrckm.stan
+++ b/inst/models/b_Klx_pi_tr_psrckm.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -53,13 +53,13 @@ parameters {
 
 transformed parameters {
   vector[d] K600_daily_predlog;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -96,7 +96,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -121,7 +121,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Klx_pi_tr_psrcko.stan
+++ b/inst/models/b_Klx_pi_tr_psrcko.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -53,13 +53,13 @@ parameters {
 
 transformed parameters {
   vector[d] K600_daily_predlog;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -96,7 +96,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -121,7 +121,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Klx_pipp_eu_plrckm.stan
+++ b/inst/models/b_Klx_pipp_eu_plrckm.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,20 +49,20 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -131,9 +131,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Klx_pipp_eu_plrcko.stan
+++ b/inst/models/b_Klx_pipp_eu_plrcko.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,20 +49,20 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -131,9 +131,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Klx_pipp_tr_plrckm.stan
+++ b/inst/models/b_Klx_pipp_tr_plrckm.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,20 +49,20 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -103,7 +103,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -134,9 +134,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Klx_pipp_tr_plrcko.stan
+++ b/inst/models/b_Klx_pipp_tr_plrcko.stan
@@ -31,12 +31,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,20 +49,20 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -103,7 +103,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -134,9 +134,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Klx_pp_eu_plrckm.stan
+++ b/inst/models/b_Klx_pp_eu_plrckm.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,18 +47,18 @@ parameters {
   real lnK600_lnQ_slope;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_mult_GPP_sdlog = err_mult_GPP_sdlog_sigma * err_mult_GPP_sdlog_scaled;
@@ -113,8 +113,8 @@ model {
   
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Klx_pp_eu_plrcko.stan
+++ b/inst/models/b_Klx_pp_eu_plrcko.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,18 +47,18 @@ parameters {
   real lnK600_lnQ_slope;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_mult_GPP_sdlog = err_mult_GPP_sdlog_sigma * err_mult_GPP_sdlog_scaled;
@@ -113,8 +113,8 @@ model {
   
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Klx_pp_tr_plrckm.stan
+++ b/inst/models/b_Klx_pp_tr_plrckm.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,18 +47,18 @@ parameters {
   real lnK600_lnQ_slope;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_mult_GPP_sdlog = err_mult_GPP_sdlog_sigma * err_mult_GPP_sdlog_scaled;
@@ -115,8 +115,8 @@ model {
   
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Klx_pp_tr_plrcko.stan
+++ b/inst/models/b_Klx_pp_tr_plrcko.stan
@@ -30,12 +30,12 @@ data {
   vector[d] lnQ_daily;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,18 +47,18 @@ parameters {
   real lnK600_lnQ_slope;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily_predlog;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_mult_GPP_sdlog = err_mult_GPP_sdlog_sigma * err_mult_GPP_sdlog_scaled;
@@ -115,8 +115,8 @@ model {
   
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kn0_oi_eu_plrckm.stan
+++ b/inst/models/b_Kn0_oi_eu_plrckm.stan
@@ -26,12 +26,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -46,10 +46,10 @@ parameters {
 transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -99,7 +99,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kn0_oi_eu_plrcko.stan
+++ b/inst/models/b_Kn0_oi_eu_plrcko.stan
@@ -26,12 +26,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -46,10 +46,10 @@ parameters {
 transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -99,7 +99,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kn0_oi_eu_psrckm.stan
+++ b/inst/models/b_Kn0_oi_eu_psrckm.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,10 +49,10 @@ transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -106,7 +106,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kn0_oi_eu_psrcko.stan
+++ b/inst/models/b_Kn0_oi_eu_psrcko.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,10 +49,10 @@ transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -106,7 +106,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kn0_oi_tr_plrckm.stan
+++ b/inst/models/b_Kn0_oi_tr_plrckm.stan
@@ -26,12 +26,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -46,10 +46,10 @@ parameters {
 transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -101,7 +101,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kn0_oi_tr_plrcko.stan
+++ b/inst/models/b_Kn0_oi_tr_plrcko.stan
@@ -26,12 +26,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -46,10 +46,10 @@ parameters {
 transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -101,7 +101,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kn0_oi_tr_psrckm.stan
+++ b/inst/models/b_Kn0_oi_tr_psrckm.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,10 +49,10 @@ transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -108,7 +108,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kn0_oi_tr_psrcko.stan
+++ b/inst/models/b_Kn0_oi_tr_psrcko.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,10 +49,10 @@ transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -108,7 +108,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kn0_oipi_eu_plrckm.stan
+++ b/inst/models/b_Kn0_oipi_eu_plrckm.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -43,18 +43,18 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -117,8 +117,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kn0_oipi_eu_plrcko.stan
+++ b/inst/models/b_Kn0_oipi_eu_plrcko.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -43,18 +43,18 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -117,8 +117,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kn0_oipi_eu_psrckm.stan
+++ b/inst/models/b_Kn0_oipi_eu_psrckm.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -45,19 +45,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -124,8 +124,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kn0_oipi_eu_psrcko.stan
+++ b/inst/models/b_Kn0_oipi_eu_psrcko.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -45,19 +45,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -124,8 +124,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kn0_oipi_tr_plrckm.stan
+++ b/inst/models/b_Kn0_oipi_tr_plrckm.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -43,18 +43,18 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -91,7 +91,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -120,8 +120,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kn0_oipi_tr_plrcko.stan
+++ b/inst/models/b_Kn0_oipi_tr_plrcko.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -43,18 +43,18 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -91,7 +91,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -120,8 +120,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kn0_oipi_tr_psrckm.stan
+++ b/inst/models/b_Kn0_oipi_tr_psrckm.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -45,19 +45,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -97,7 +97,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -127,8 +127,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kn0_oipi_tr_psrcko.stan
+++ b/inst/models/b_Kn0_oipi_tr_psrcko.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -45,19 +45,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -97,7 +97,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -127,8 +127,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kn0_oipipp_eu_plrckm.stan
+++ b/inst/models/b_Kn0_oipipp_eu_plrckm.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -45,22 +45,22 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -137,10 +137,10 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kn0_oipipp_eu_plrcko.stan
+++ b/inst/models/b_Kn0_oipipp_eu_plrcko.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -45,22 +45,22 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -137,10 +137,10 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kn0_oipipp_tr_plrckm.stan
+++ b/inst/models/b_Kn0_oipipp_tr_plrckm.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -45,22 +45,22 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -104,7 +104,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -140,10 +140,10 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kn0_oipipp_tr_plrcko.stan
+++ b/inst/models/b_Kn0_oipipp_tr_plrcko.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -45,22 +45,22 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -104,7 +104,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -140,10 +140,10 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kn0_oipp_eu_plrckm.stan
+++ b/inst/models/b_Kn0_oipp_eu_plrckm.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -43,19 +43,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -119,9 +119,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kn0_oipp_eu_plrcko.stan
+++ b/inst/models/b_Kn0_oipp_eu_plrcko.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -43,19 +43,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -119,9 +119,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kn0_oipp_tr_plrckm.stan
+++ b/inst/models/b_Kn0_oipp_tr_plrckm.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -43,19 +43,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -121,9 +121,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kn0_oipp_tr_plrcko.stan
+++ b/inst/models/b_Kn0_oipp_tr_plrcko.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -43,19 +43,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -121,9 +121,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kn0_pi_eu_plrckm.stan
+++ b/inst/models/b_Kn0_pi_eu_plrckm.stan
@@ -26,12 +26,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -45,12 +45,12 @@ parameters {
 
 transformed parameters {
   vector[d] K600_daily;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -105,7 +105,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kn0_pi_eu_plrcko.stan
+++ b/inst/models/b_Kn0_pi_eu_plrcko.stan
@@ -26,12 +26,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -45,12 +45,12 @@ parameters {
 
 transformed parameters {
   vector[d] K600_daily;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -105,7 +105,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kn0_pi_eu_psrckm.stan
+++ b/inst/models/b_Kn0_pi_eu_psrckm.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,13 +47,13 @@ parameters {
 
 transformed parameters {
   vector[d] K600_daily;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -112,7 +112,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kn0_pi_eu_psrcko.stan
+++ b/inst/models/b_Kn0_pi_eu_psrcko.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,13 +47,13 @@ parameters {
 
 transformed parameters {
   vector[d] K600_daily;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -112,7 +112,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kn0_pi_tr_plrckm.stan
+++ b/inst/models/b_Kn0_pi_tr_plrckm.stan
@@ -26,12 +26,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -45,12 +45,12 @@ parameters {
 
 transformed parameters {
   vector[d] K600_daily;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -86,7 +86,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -108,7 +108,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kn0_pi_tr_plrcko.stan
+++ b/inst/models/b_Kn0_pi_tr_plrcko.stan
@@ -26,12 +26,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -45,12 +45,12 @@ parameters {
 
 transformed parameters {
   vector[d] K600_daily;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -86,7 +86,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -108,7 +108,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kn0_pi_tr_psrckm.stan
+++ b/inst/models/b_Kn0_pi_tr_psrckm.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,13 +47,13 @@ parameters {
 
 transformed parameters {
   vector[d] K600_daily;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -92,7 +92,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -115,7 +115,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kn0_pi_tr_psrcko.stan
+++ b/inst/models/b_Kn0_pi_tr_psrcko.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,13 +47,13 @@ parameters {
 
 transformed parameters {
   vector[d] K600_daily;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -92,7 +92,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -115,7 +115,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kn0_pipp_eu_plrckm.stan
+++ b/inst/models/b_Kn0_pipp_eu_plrckm.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -43,20 +43,20 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -125,9 +125,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kn0_pipp_eu_plrcko.stan
+++ b/inst/models/b_Kn0_pipp_eu_plrcko.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -43,20 +43,20 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -125,9 +125,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kn0_pipp_tr_plrckm.stan
+++ b/inst/models/b_Kn0_pipp_tr_plrckm.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -43,20 +43,20 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -99,7 +99,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -128,9 +128,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kn0_pipp_tr_plrcko.stan
+++ b/inst/models/b_Kn0_pipp_tr_plrcko.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -43,20 +43,20 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -99,7 +99,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -128,9 +128,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kn0_pp_eu_plrckm.stan
+++ b/inst/models/b_Kn0_pp_eu_plrckm.stan
@@ -26,12 +26,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -41,18 +41,18 @@ parameters {
   real K600_daily_predlog;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_mult_GPP_sdlog = err_mult_GPP_sdlog_sigma * err_mult_GPP_sdlog_scaled;
@@ -107,8 +107,8 @@ model {
   
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kn0_pp_eu_plrcko.stan
+++ b/inst/models/b_Kn0_pp_eu_plrcko.stan
@@ -26,12 +26,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -41,18 +41,18 @@ parameters {
   real K600_daily_predlog;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_mult_GPP_sdlog = err_mult_GPP_sdlog_sigma * err_mult_GPP_sdlog_scaled;
@@ -107,8 +107,8 @@ model {
   
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kn0_pp_tr_plrckm.stan
+++ b/inst/models/b_Kn0_pp_tr_plrckm.stan
@@ -26,12 +26,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -41,18 +41,18 @@ parameters {
   real K600_daily_predlog;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_mult_GPP_sdlog = err_mult_GPP_sdlog_sigma * err_mult_GPP_sdlog_scaled;
@@ -109,8 +109,8 @@ model {
   
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kn0_pp_tr_plrcko.stan
+++ b/inst/models/b_Kn0_pp_tr_plrcko.stan
@@ -26,12 +26,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -41,18 +41,18 @@ parameters {
   real K600_daily_predlog;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   vector[d] K600_daily;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_mult_GPP_sdlog = err_mult_GPP_sdlog_sigma * err_mult_GPP_sdlog_scaled;
@@ -109,8 +109,8 @@ model {
   
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kn_oi_eu_plrckm.stan
+++ b/inst/models/b_Kn_oi_eu_plrckm.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,10 +49,10 @@ parameters {
 transformed parameters {
   real<lower=0> K600_daily_sdlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -102,7 +102,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kn_oi_eu_plrcko.stan
+++ b/inst/models/b_Kn_oi_eu_plrcko.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,10 +49,10 @@ parameters {
 transformed parameters {
   real<lower=0> K600_daily_sdlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -102,7 +102,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kn_oi_eu_psrckm.stan
+++ b/inst/models/b_Kn_oi_eu_psrckm.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -52,10 +52,10 @@ transformed parameters {
   real<lower=0> K600_daily_sdlog;
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -109,7 +109,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kn_oi_eu_psrcko.stan
+++ b/inst/models/b_Kn_oi_eu_psrcko.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -52,10 +52,10 @@ transformed parameters {
   real<lower=0> K600_daily_sdlog;
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -109,7 +109,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kn_oi_tr_plrckm.stan
+++ b/inst/models/b_Kn_oi_tr_plrckm.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,10 +49,10 @@ parameters {
 transformed parameters {
   real<lower=0> K600_daily_sdlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -104,7 +104,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kn_oi_tr_plrcko.stan
+++ b/inst/models/b_Kn_oi_tr_plrcko.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -49,10 +49,10 @@ parameters {
 transformed parameters {
   real<lower=0> K600_daily_sdlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -104,7 +104,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kn_oi_tr_psrckm.stan
+++ b/inst/models/b_Kn_oi_tr_psrckm.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -52,10 +52,10 @@ transformed parameters {
   real<lower=0> K600_daily_sdlog;
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -111,7 +111,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kn_oi_tr_psrcko.stan
+++ b/inst/models/b_Kn_oi_tr_psrcko.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -52,10 +52,10 @@ transformed parameters {
   real<lower=0> K600_daily_sdlog;
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -111,7 +111,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kn_oipi_eu_plrckm.stan
+++ b/inst/models/b_Kn_oipi_eu_plrckm.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -46,18 +46,18 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   real<lower=0> K600_daily_sdlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -120,8 +120,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kn_oipi_eu_plrcko.stan
+++ b/inst/models/b_Kn_oipi_eu_plrcko.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -46,18 +46,18 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   real<lower=0> K600_daily_sdlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -120,8 +120,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kn_oipi_eu_psrckm.stan
+++ b/inst/models/b_Kn_oipi_eu_psrckm.stan
@@ -29,12 +29,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -48,19 +48,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   real<lower=0> K600_daily_sdlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -127,8 +127,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kn_oipi_eu_psrcko.stan
+++ b/inst/models/b_Kn_oipi_eu_psrcko.stan
@@ -29,12 +29,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -48,19 +48,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   real<lower=0> K600_daily_sdlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -127,8 +127,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kn_oipi_tr_plrckm.stan
+++ b/inst/models/b_Kn_oipi_tr_plrckm.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -46,18 +46,18 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   real<lower=0> K600_daily_sdlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -92,7 +92,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -123,8 +123,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kn_oipi_tr_plrcko.stan
+++ b/inst/models/b_Kn_oipi_tr_plrcko.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -46,18 +46,18 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   real<lower=0> K600_daily_sdlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -92,7 +92,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -123,8 +123,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kn_oipi_tr_psrckm.stan
+++ b/inst/models/b_Kn_oipi_tr_psrckm.stan
@@ -29,12 +29,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -48,19 +48,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   real<lower=0> K600_daily_sdlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -98,7 +98,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -130,8 +130,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kn_oipi_tr_psrcko.stan
+++ b/inst/models/b_Kn_oipi_tr_psrcko.stan
@@ -29,12 +29,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -48,19 +48,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   real<lower=0> K600_daily_sdlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -98,7 +98,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -130,8 +130,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Kn_oipipp_eu_plrckm.stan
+++ b/inst/models/b_Kn_oipipp_eu_plrckm.stan
@@ -29,12 +29,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -48,22 +48,22 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   real<lower=0> K600_daily_sdlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -140,10 +140,10 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kn_oipipp_eu_plrcko.stan
+++ b/inst/models/b_Kn_oipipp_eu_plrcko.stan
@@ -29,12 +29,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -48,22 +48,22 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   real<lower=0> K600_daily_sdlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -140,10 +140,10 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kn_oipipp_tr_plrckm.stan
+++ b/inst/models/b_Kn_oipipp_tr_plrckm.stan
@@ -29,12 +29,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -48,22 +48,22 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   real<lower=0> K600_daily_sdlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -105,7 +105,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -143,10 +143,10 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kn_oipipp_tr_plrcko.stan
+++ b/inst/models/b_Kn_oipipp_tr_plrcko.stan
@@ -29,12 +29,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -48,22 +48,22 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   real<lower=0> K600_daily_sdlog;
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -105,7 +105,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -143,10 +143,10 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kn_oipp_eu_plrckm.stan
+++ b/inst/models/b_Kn_oipp_eu_plrckm.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -46,19 +46,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   real<lower=0> K600_daily_sdlog;
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -122,9 +122,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kn_oipp_eu_plrcko.stan
+++ b/inst/models/b_Kn_oipp_eu_plrcko.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -46,19 +46,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   real<lower=0> K600_daily_sdlog;
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -122,9 +122,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kn_oipp_tr_plrckm.stan
+++ b/inst/models/b_Kn_oipp_tr_plrckm.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -46,19 +46,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   real<lower=0> K600_daily_sdlog;
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -124,9 +124,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kn_oipp_tr_plrcko.stan
+++ b/inst/models/b_Kn_oipp_tr_plrcko.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -46,19 +46,19 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   real<lower=0> K600_daily_sdlog;
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -124,9 +124,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kn_pi_eu_plrckm.stan
+++ b/inst/models/b_Kn_pi_eu_plrckm.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -48,12 +48,12 @@ parameters {
 
 transformed parameters {
   real<lower=0> K600_daily_sdlog;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -108,7 +108,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kn_pi_eu_plrcko.stan
+++ b/inst/models/b_Kn_pi_eu_plrcko.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -48,12 +48,12 @@ parameters {
 
 transformed parameters {
   real<lower=0> K600_daily_sdlog;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -108,7 +108,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kn_pi_eu_psrckm.stan
+++ b/inst/models/b_Kn_pi_eu_psrckm.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,13 +50,13 @@ parameters {
 
 transformed parameters {
   real<lower=0> K600_daily_sdlog;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -115,7 +115,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kn_pi_eu_psrcko.stan
+++ b/inst/models/b_Kn_pi_eu_psrcko.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,13 +50,13 @@ parameters {
 
 transformed parameters {
   real<lower=0> K600_daily_sdlog;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -115,7 +115,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kn_pi_tr_plrckm.stan
+++ b/inst/models/b_Kn_pi_tr_plrckm.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -48,12 +48,12 @@ parameters {
 
 transformed parameters {
   real<lower=0> K600_daily_sdlog;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -87,7 +87,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -111,7 +111,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kn_pi_tr_plrcko.stan
+++ b/inst/models/b_Kn_pi_tr_plrcko.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -48,12 +48,12 @@ parameters {
 
 transformed parameters {
   real<lower=0> K600_daily_sdlog;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -87,7 +87,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -111,7 +111,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kn_pi_tr_psrckm.stan
+++ b/inst/models/b_Kn_pi_tr_psrckm.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,13 +50,13 @@ parameters {
 
 transformed parameters {
   real<lower=0> K600_daily_sdlog;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -93,7 +93,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -118,7 +118,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kn_pi_tr_psrcko.stan
+++ b/inst/models/b_Kn_pi_tr_psrcko.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,13 +50,13 @@ parameters {
 
 transformed parameters {
   real<lower=0> K600_daily_sdlog;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -93,7 +93,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -118,7 +118,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Kn_pipp_eu_plrckm.stan
+++ b/inst/models/b_Kn_pipp_eu_plrckm.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -46,20 +46,20 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   real<lower=0> K600_daily_sdlog;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -128,9 +128,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kn_pipp_eu_plrcko.stan
+++ b/inst/models/b_Kn_pipp_eu_plrcko.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -46,20 +46,20 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   real<lower=0> K600_daily_sdlog;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -128,9 +128,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kn_pipp_tr_plrckm.stan
+++ b/inst/models/b_Kn_pipp_tr_plrckm.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -46,20 +46,20 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   real<lower=0> K600_daily_sdlog;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -100,7 +100,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -131,9 +131,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kn_pipp_tr_plrcko.stan
+++ b/inst/models/b_Kn_pipp_tr_plrcko.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -46,20 +46,20 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   real<lower=0> K600_daily_sdlog;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -100,7 +100,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -131,9 +131,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kn_pp_eu_plrckm.stan
+++ b/inst/models/b_Kn_pp_eu_plrckm.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -44,18 +44,18 @@ parameters {
   real<lower=0> K600_daily_sdlog_scaled;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   real<lower=0> K600_daily_sdlog;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -110,8 +110,8 @@ model {
   
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kn_pp_eu_plrcko.stan
+++ b/inst/models/b_Kn_pp_eu_plrcko.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -44,18 +44,18 @@ parameters {
   real<lower=0> K600_daily_sdlog_scaled;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   real<lower=0> K600_daily_sdlog;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -110,8 +110,8 @@ model {
   
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kn_pp_tr_plrckm.stan
+++ b/inst/models/b_Kn_pp_tr_plrckm.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -44,18 +44,18 @@ parameters {
   real<lower=0> K600_daily_sdlog_scaled;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   real<lower=0> K600_daily_sdlog;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -112,8 +112,8 @@ model {
   
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Kn_pp_tr_plrcko.stan
+++ b/inst/models/b_Kn_pp_tr_plrcko.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -44,18 +44,18 @@ parameters {
   real<lower=0> K600_daily_sdlog_scaled;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   real<lower=0> K600_daily_sdlog;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale pooling distribution parameter
   K600_daily_sdlog = K600_daily_sdlog_sigma * K600_daily_sdlog_scaled;
@@ -112,8 +112,8 @@ model {
   
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Knx_oi_eu_plrckm.stan
+++ b/inst/models/b_Knx_oi_eu_plrckm.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,10 +47,10 @@ parameters {
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -96,7 +96,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Knx_oi_eu_plrcko.stan
+++ b/inst/models/b_Knx_oi_eu_plrcko.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,10 +47,10 @@ parameters {
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -96,7 +96,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Knx_oi_eu_psrckm.stan
+++ b/inst/models/b_Knx_oi_eu_psrckm.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,10 +50,10 @@ parameters {
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -103,7 +103,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Knx_oi_eu_psrcko.stan
+++ b/inst/models/b_Knx_oi_eu_psrcko.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,10 +50,10 @@ parameters {
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -103,7 +103,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Knx_oi_tr_plrckm.stan
+++ b/inst/models/b_Knx_oi_tr_plrckm.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,10 +47,10 @@ parameters {
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -98,7 +98,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Knx_oi_tr_plrcko.stan
+++ b/inst/models/b_Knx_oi_tr_plrcko.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,10 +47,10 @@ parameters {
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -98,7 +98,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Knx_oi_tr_psrckm.stan
+++ b/inst/models/b_Knx_oi_tr_psrckm.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,10 +50,10 @@ parameters {
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -105,7 +105,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Knx_oi_tr_psrcko.stan
+++ b/inst/models/b_Knx_oi_tr_psrcko.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -50,10 +50,10 @@ parameters {
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -105,7 +105,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Knx_oipi_eu_plrckm.stan
+++ b/inst/models/b_Knx_oipi_eu_plrckm.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -45,17 +45,17 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -114,8 +114,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Knx_oipi_eu_plrcko.stan
+++ b/inst/models/b_Knx_oipi_eu_plrcko.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -45,17 +45,17 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -114,8 +114,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Knx_oipi_eu_psrckm.stan
+++ b/inst/models/b_Knx_oipi_eu_psrckm.stan
@@ -29,12 +29,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,18 +47,18 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -121,8 +121,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Knx_oipi_eu_psrcko.stan
+++ b/inst/models/b_Knx_oipi_eu_psrcko.stan
@@ -29,12 +29,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,18 +47,18 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -121,8 +121,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Knx_oipi_tr_plrckm.stan
+++ b/inst/models/b_Knx_oipi_tr_plrckm.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -45,17 +45,17 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -87,7 +87,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -117,8 +117,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Knx_oipi_tr_plrcko.stan
+++ b/inst/models/b_Knx_oipi_tr_plrcko.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -45,17 +45,17 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -87,7 +87,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -117,8 +117,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Knx_oipi_tr_psrckm.stan
+++ b/inst/models/b_Knx_oipi_tr_psrckm.stan
@@ -29,12 +29,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,18 +47,18 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -93,7 +93,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -124,8 +124,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Knx_oipi_tr_psrcko.stan
+++ b/inst/models/b_Knx_oipi_tr_psrcko.stan
@@ -29,12 +29,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,18 +47,18 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -93,7 +93,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -124,8 +124,8 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_Knx_oipipp_eu_plrckm.stan
+++ b/inst/models/b_Knx_oipipp_eu_plrckm.stan
@@ -29,12 +29,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,21 +47,21 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -134,10 +134,10 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Knx_oipipp_eu_plrcko.stan
+++ b/inst/models/b_Knx_oipipp_eu_plrcko.stan
@@ -29,12 +29,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,21 +47,21 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -134,10 +134,10 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Knx_oipipp_tr_plrckm.stan
+++ b/inst/models/b_Knx_oipipp_tr_plrckm.stan
@@ -29,12 +29,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,21 +47,21 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -100,7 +100,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -137,10 +137,10 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Knx_oipipp_tr_plrcko.stan
+++ b/inst/models/b_Knx_oipipp_tr_plrcko.stan
@@ -29,12 +29,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -47,21 +47,21 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -100,7 +100,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -137,10 +137,10 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Knx_oipp_eu_plrckm.stan
+++ b/inst/models/b_Knx_oipp_eu_plrckm.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -45,18 +45,18 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -116,9 +116,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Knx_oipp_eu_plrcko.stan
+++ b/inst/models/b_Knx_oipp_eu_plrcko.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -45,18 +45,18 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -116,9 +116,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Knx_oipp_tr_plrckm.stan
+++ b/inst/models/b_Knx_oipp_tr_plrckm.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -45,18 +45,18 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -118,9 +118,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Knx_oipp_tr_plrcko.stan
+++ b/inst/models/b_Knx_oipp_tr_plrcko.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -45,18 +45,18 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -118,9 +118,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Knx_pi_eu_plrckm.stan
+++ b/inst/models/b_Knx_pi_eu_plrckm.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -46,12 +46,12 @@ parameters {
 }
 
 transformed parameters {
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -102,7 +102,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Knx_pi_eu_plrcko.stan
+++ b/inst/models/b_Knx_pi_eu_plrcko.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -46,12 +46,12 @@ parameters {
 }
 
 transformed parameters {
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -102,7 +102,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Knx_pi_eu_psrckm.stan
+++ b/inst/models/b_Knx_pi_eu_psrckm.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -48,13 +48,13 @@ parameters {
 }
 
 transformed parameters {
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -109,7 +109,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Knx_pi_eu_psrcko.stan
+++ b/inst/models/b_Knx_pi_eu_psrcko.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -48,13 +48,13 @@ parameters {
 }
 
 transformed parameters {
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -109,7 +109,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Knx_pi_tr_plrckm.stan
+++ b/inst/models/b_Knx_pi_tr_plrckm.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -46,12 +46,12 @@ parameters {
 }
 
 transformed parameters {
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -82,7 +82,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -105,7 +105,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Knx_pi_tr_plrcko.stan
+++ b/inst/models/b_Knx_pi_tr_plrcko.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -46,12 +46,12 @@ parameters {
 }
 
 transformed parameters {
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -82,7 +82,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -105,7 +105,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Knx_pi_tr_psrckm.stan
+++ b/inst/models/b_Knx_pi_tr_psrckm.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -48,13 +48,13 @@ parameters {
 }
 
 transformed parameters {
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -88,7 +88,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -112,7 +112,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Knx_pi_tr_psrcko.stan
+++ b/inst/models/b_Knx_pi_tr_psrcko.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -48,13 +48,13 @@ parameters {
 }
 
 transformed parameters {
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -88,7 +88,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -112,7 +112,7 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_Knx_pipp_eu_plrckm.stan
+++ b/inst/models/b_Knx_pipp_eu_plrckm.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -45,19 +45,19 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -122,9 +122,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Knx_pipp_eu_plrcko.stan
+++ b/inst/models/b_Knx_pipp_eu_plrcko.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -45,19 +45,19 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -122,9 +122,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Knx_pipp_tr_plrckm.stan
+++ b/inst/models/b_Knx_pipp_tr_plrckm.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -45,19 +45,19 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -95,7 +95,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -125,9 +125,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Knx_pipp_tr_plrcko.stan
+++ b/inst/models/b_Knx_pipp_tr_plrcko.stan
@@ -28,12 +28,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -45,19 +45,19 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -95,7 +95,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -125,9 +125,9 @@ model {
   
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Knx_pp_eu_plrckm.stan
+++ b/inst/models/b_Knx_pp_eu_plrckm.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -43,17 +43,17 @@ parameters {
   real K600_daily_predlog;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_mult_GPP_sdlog = err_mult_GPP_sdlog_sigma * err_mult_GPP_sdlog_scaled;
@@ -104,8 +104,8 @@ model {
   
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Knx_pp_eu_plrcko.stan
+++ b/inst/models/b_Knx_pp_eu_plrcko.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -43,17 +43,17 @@ parameters {
   real K600_daily_predlog;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_mult_GPP_sdlog = err_mult_GPP_sdlog_sigma * err_mult_GPP_sdlog_scaled;
@@ -104,8 +104,8 @@ model {
   
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Knx_pp_tr_plrckm.stan
+++ b/inst/models/b_Knx_pp_tr_plrckm.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -43,17 +43,17 @@ parameters {
   real K600_daily_predlog;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_mult_GPP_sdlog = err_mult_GPP_sdlog_sigma * err_mult_GPP_sdlog_scaled;
@@ -106,8 +106,8 @@ model {
   
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_Knx_pp_tr_plrcko.stan
+++ b/inst/models/b_Knx_pp_tr_plrcko.stan
@@ -27,12 +27,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -43,17 +43,17 @@ parameters {
   real K600_daily_predlog;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_mult_GPP_sdlog = err_mult_GPP_sdlog_sigma * err_mult_GPP_sdlog_scaled;
@@ -106,8 +106,8 @@ model {
   
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_np_oi_eu_plrckm.stan
+++ b/inst/models/b_np_oi_eu_plrckm.stan
@@ -24,12 +24,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -42,10 +42,10 @@ parameters {
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -88,7 +88,7 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_np_oi_eu_plrcko.stan
+++ b/inst/models/b_np_oi_eu_plrcko.stan
@@ -24,12 +24,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -42,10 +42,10 @@ parameters {
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -88,7 +88,7 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_np_oi_eu_psrckm.stan
+++ b/inst/models/b_np_oi_eu_psrckm.stan
@@ -25,12 +25,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -45,10 +45,10 @@ parameters {
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -95,7 +95,7 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_np_oi_eu_psrcko.stan
+++ b/inst/models/b_np_oi_eu_psrcko.stan
@@ -25,12 +25,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -45,10 +45,10 @@ parameters {
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -95,7 +95,7 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_np_oi_tr_plrckm.stan
+++ b/inst/models/b_np_oi_tr_plrckm.stan
@@ -24,12 +24,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -42,10 +42,10 @@ parameters {
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -90,7 +90,7 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_np_oi_tr_plrcko.stan
+++ b/inst/models/b_np_oi_tr_plrcko.stan
@@ -24,12 +24,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -42,10 +42,10 @@ parameters {
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -90,7 +90,7 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_np_oi_tr_psrckm.stan
+++ b/inst/models/b_np_oi_tr_psrckm.stan
@@ -25,12 +25,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -45,10 +45,10 @@ parameters {
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -97,7 +97,7 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_np_oi_tr_psrcko.stan
+++ b/inst/models/b_np_oi_tr_psrcko.stan
@@ -25,12 +25,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -45,10 +45,10 @@ parameters {
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -97,7 +97,7 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
+  array[n] vector[d] err_obs_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_np_oipi_eu_plrckm.stan
+++ b/inst/models/b_np_oipi_eu_plrckm.stan
@@ -25,12 +25,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -40,17 +40,17 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -106,8 +106,8 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_np_oipi_eu_plrcko.stan
+++ b/inst/models/b_np_oipi_eu_plrcko.stan
@@ -25,12 +25,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -40,17 +40,17 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -106,8 +106,8 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_np_oipi_eu_psrckm.stan
+++ b/inst/models/b_np_oipi_eu_psrckm.stan
@@ -26,12 +26,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -42,18 +42,18 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -113,8 +113,8 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_np_oipi_eu_psrcko.stan
+++ b/inst/models/b_np_oipi_eu_psrcko.stan
@@ -26,12 +26,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -42,18 +42,18 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -113,8 +113,8 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_np_oipi_tr_plrckm.stan
+++ b/inst/models/b_np_oipi_tr_plrckm.stan
@@ -25,12 +25,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -40,17 +40,17 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -82,7 +82,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -109,8 +109,8 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_np_oipi_tr_plrcko.stan
+++ b/inst/models/b_np_oipi_tr_plrcko.stan
@@ -25,12 +25,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -40,17 +40,17 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -82,7 +82,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -109,8 +109,8 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_np_oipi_tr_psrckm.stan
+++ b/inst/models/b_np_oipi_tr_psrckm.stan
@@ -26,12 +26,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -42,18 +42,18 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -88,7 +88,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -116,8 +116,8 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_np_oipi_tr_psrcko.stan
+++ b/inst/models/b_np_oipi_tr_psrcko.stan
@@ -26,12 +26,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -42,18 +42,18 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -88,7 +88,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -116,8 +116,8 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[n] DO_obs_vec; // temporary

--- a/inst/models/b_np_oipipp_eu_plrckm.stan
+++ b/inst/models/b_np_oipipp_eu_plrckm.stan
@@ -26,12 +26,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -42,21 +42,21 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -126,10 +126,10 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_np_oipipp_eu_plrcko.stan
+++ b/inst/models/b_np_oipipp_eu_plrcko.stan
@@ -26,12 +26,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -42,21 +42,21 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -126,10 +126,10 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_np_oipipp_tr_plrckm.stan
+++ b/inst/models/b_np_oipipp_tr_plrckm.stan
@@ -26,12 +26,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -42,21 +42,21 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -95,7 +95,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -129,10 +129,10 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_np_oipipp_tr_plrcko.stan
+++ b/inst/models/b_np_oipipp_tr_plrcko.stan
@@ -26,12 +26,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -42,21 +42,21 @@ parameters {
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
-  vector[d] DO_mod[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
+  array[n] vector[d] DO_mod;
 }
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -95,7 +95,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -129,10 +129,10 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_np_oipp_eu_plrckm.stan
+++ b/inst/models/b_np_oipp_eu_plrckm.stan
@@ -25,12 +25,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -40,18 +40,18 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -108,9 +108,9 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_np_oipp_eu_plrcko.stan
+++ b/inst/models/b_np_oipp_eu_plrcko.stan
@@ -25,12 +25,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -40,18 +40,18 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -108,9 +108,9 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_np_oipp_tr_plrckm.stan
+++ b/inst/models/b_np_oipp_tr_plrckm.stan
@@ -25,12 +25,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -40,18 +40,18 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -110,9 +110,9 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_np_oipp_tr_plrcko.stan
+++ b/inst/models/b_np_oipp_tr_plrcko.stan
@@ -25,12 +25,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -40,18 +40,18 @@ parameters {
   
   real<lower=0> err_obs_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   real<lower=0> err_obs_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_obs_iid_sigma = err_obs_iid_sigma_scale * err_obs_iid_sigma_scaled;
@@ -110,9 +110,9 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] err_obs_iid[n];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] err_obs_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_np_pi_eu_plrckm.stan
+++ b/inst/models/b_np_pi_eu_plrckm.stan
@@ -24,12 +24,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -41,12 +41,12 @@ parameters {
 }
 
 transformed parameters {
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -94,7 +94,7 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_np_pi_eu_plrcko.stan
+++ b/inst/models/b_np_pi_eu_plrcko.stan
@@ -24,12 +24,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -41,12 +41,12 @@ parameters {
 }
 
 transformed parameters {
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -94,7 +94,7 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_np_pi_eu_psrckm.stan
+++ b/inst/models/b_np_pi_eu_psrckm.stan
@@ -25,12 +25,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -43,13 +43,13 @@ parameters {
 }
 
 transformed parameters {
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -101,7 +101,7 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_np_pi_eu_psrcko.stan
+++ b/inst/models/b_np_pi_eu_psrcko.stan
@@ -25,12 +25,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -43,13 +43,13 @@ parameters {
 }
 
 transformed parameters {
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -101,7 +101,7 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_np_pi_tr_plrckm.stan
+++ b/inst/models/b_np_pi_tr_plrckm.stan
@@ -24,12 +24,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -41,12 +41,12 @@ parameters {
 }
 
 transformed parameters {
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -77,7 +77,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -97,7 +97,7 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_np_pi_tr_plrcko.stan
+++ b/inst/models/b_np_pi_tr_plrcko.stan
@@ -24,12 +24,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -41,12 +41,12 @@ parameters {
 }
 
 transformed parameters {
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -77,7 +77,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -97,7 +97,7 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_np_pi_tr_psrckm.stan
+++ b/inst/models/b_np_pi_tr_psrckm.stan
@@ -25,12 +25,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -43,13 +43,13 @@ parameters {
 }
 
 transformed parameters {
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -83,7 +83,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -104,7 +104,7 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_np_pi_tr_psrcko.stan
+++ b/inst/models/b_np_pi_tr_psrcko.stan
@@ -25,12 +25,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -43,13 +43,13 @@ parameters {
 }
 
 transformed parameters {
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   vector<lower=0>[d] alpha;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -83,7 +83,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -104,7 +104,7 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
+  array[n-1] vector[d] err_proc_iid;
   vector[d] GPP;
   vector[d] ER;
   vector[d] DO_R2;

--- a/inst/models/b_np_pipp_eu_plrckm.stan
+++ b/inst/models/b_np_pipp_eu_plrckm.stan
@@ -25,12 +25,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -40,19 +40,19 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -114,9 +114,9 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_np_pipp_eu_plrcko.stan
+++ b/inst/models/b_np_pipp_eu_plrcko.stan
@@ -25,12 +25,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -40,19 +40,19 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -114,9 +114,9 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_np_pipp_tr_plrckm.stan
+++ b/inst/models/b_np_pipp_tr_plrckm.stan
@@ -25,12 +25,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -40,19 +40,19 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -90,7 +90,7 @@ transformed parameters {
       ) .* (timestep ./ (2.0 + KO2_inst[i+1] * timestep));
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / (2.0 + KO2_inst[i+1,j] * timestep));
     }
   }
@@ -117,9 +117,9 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_np_pipp_tr_plrcko.stan
+++ b/inst/models/b_np_pipp_tr_plrcko.stan
@@ -25,12 +25,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -40,19 +40,19 @@ parameters {
   
   real<lower=0> err_proc_iid_sigma_scaled;
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
-  vector[d] DO_mod_partial_sigma[n];
+  array[n] vector[d] DO_mod_partial_sigma;
   real<lower=0> err_proc_iid_sigma;
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod_partial[n];
+  array[n] vector[d] DO_mod_partial;
   
   // Rescale error distribution parameters
   err_proc_iid_sigma = err_proc_iid_sigma_scale * err_proc_iid_sigma_scaled;
@@ -90,7 +90,7 @@ transformed parameters {
       ) * (timestep / 2.0);
     for(j in 1:d) {
       DO_mod_partial_sigma[i+1,j] = err_proc_iid_sigma * 
-        sqrt(pow(depth[i,j], -2) + pow(depth[i+1,j], -2)) .*
+        sqrt(inv_square(depth[i,j]) + inv_square(depth[i+1,j])) .*
         (timestep / 2.0);
     }
   }
@@ -117,9 +117,9 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] err_proc_iid[n-1];
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n-1] vector[d] err_proc_iid;
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_np_pp_eu_plrckm.stan
+++ b/inst/models/b_np_pp_eu_plrckm.stan
@@ -24,12 +24,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -38,17 +38,17 @@ parameters {
   vector<lower=0>[d] K600_daily;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_mult_GPP_sdlog = err_mult_GPP_sdlog_sigma * err_mult_GPP_sdlog_scaled;
@@ -96,8 +96,8 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_np_pp_eu_plrcko.stan
+++ b/inst/models/b_np_pp_eu_plrcko.stan
@@ -24,12 +24,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -38,17 +38,17 @@ parameters {
   vector<lower=0>[d] K600_daily;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_mult_GPP_sdlog = err_mult_GPP_sdlog_sigma * err_mult_GPP_sdlog_scaled;
@@ -96,8 +96,8 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_np_pp_tr_plrckm.stan
+++ b/inst/models/b_np_pp_tr_plrckm.stan
@@ -24,12 +24,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -38,17 +38,17 @@ parameters {
   vector<lower=0>[d] K600_daily;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_mult_GPP_sdlog = err_mult_GPP_sdlog_sigma * err_mult_GPP_sdlog_scaled;
@@ -98,8 +98,8 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary

--- a/inst/models/b_np_pp_tr_plrcko.stan
+++ b/inst/models/b_np_pp_tr_plrcko.stan
@@ -24,12 +24,12 @@ data {
   vector[d] DO_obs_1;
   
   // Data
-  vector[d] DO_obs[n];
-  vector[d] DO_sat[n];
-  vector[d] light_mult_GPP[n];
-  vector[d] const_mult_ER[n];
-  vector[d] depth[n];
-  vector[d] KO2_conv[n];
+  array[n] vector[d] DO_obs;
+  array[n] vector[d] DO_sat;
+  array[n] vector[d] light_mult_GPP;
+  array[n] vector[d] const_mult_ER;
+  array[n] vector[d] depth;
+  array[n] vector[d] KO2_conv;
 }
 
 parameters {
@@ -38,17 +38,17 @@ parameters {
   vector<lower=0>[d] K600_daily;
   
   real<lower=0> err_mult_GPP_sdlog_scaled;
-  vector<lower=0>[d] err_mult_GPP[n];
+  array[n] vector<lower=0>[d] err_mult_GPP;
 }
 
 transformed parameters {
   real<lower=0> err_mult_GPP_sdlog;
-  vector[d] GPP_inst[n];
-  vector[d] ER_inst[n];
-  vector[d] KO2_inst[n];
-  vector<lower=0>[d] combo_mult_GPP[n];
+  array[n] vector[d] GPP_inst;
+  array[n] vector[d] ER_inst;
+  array[n] vector[d] KO2_inst;
+  array[n] vector<lower=0>[d] combo_mult_GPP;
   vector<lower=0>[d] mean_combo_mult_GPP;
-  vector[d] DO_mod[n];
+  array[n] vector[d] DO_mod;
   
   // Rescale error distribution parameters
   err_mult_GPP_sdlog = err_mult_GPP_sdlog_sigma * err_mult_GPP_sdlog_scaled;
@@ -98,8 +98,8 @@ model {
   K600_daily ~ lognormal(K600_daily_meanlog, K600_daily_sdlog);
 }
 generated quantities {
-  vector[d] GPP_inst_partial[n];
-  vector[d] err_proc_GPP[n];
+  array[n] vector[d] GPP_inst_partial;
+  array[n] vector[d] err_proc_GPP;
   int n_light_day; // temporary
   vector[n] GPP_inst_day; // temporary
   vector[n] GPP_inst_diff_day; // temporary


### PR DESCRIPTION
## Modernize Stan array declaration syntax for Stan 2.33+ compatibility

### Background

Stan deprecated postfix array declaration syntax (e.g. `vector[d] x[n]`) in Stan 2.26 and removed it as a hard parse error in Stan 2.33. This package's Stan models are dynamically generated by `mm_generate_mcmc_file()` and all used the old postfix syntax — meaning all 400 generated `.stan` files fail to compile under any Stan 2.33+ toolchain (confirmed: CmdStan 2.38.0 produces a fatal parse error on every model).

This is currently latent for users on CRAN `rstan` 2.32.x, which bundles Stan 2.32.2 (one version before the hard-error cutoff) and compiles the old syntax cleanly with no warnings. No user-facing issues have been filed. However it becomes a hard breakage if/when rstan ships a version bundling Stan 2.33+, or if CmdStanR support is adopted. This PR fixes it now, since the new syntax is fully backward-compatible with rstan 2.32.x.

### What changed

`R/mm_generate_mcmc_file.R` — 23 string-template edits converting postfix array declarations to `array[N] type` syntax across four Stan blocks:
- **data block**: 7 unconditional declarations + 2 binned-K600-specific declarations (including one 2D case)
- **parameters block**: 3 conditional declarations (error-structure-specific)
- **transformed parameters block**: 8 declarations (partially conditional)
- **generated quantities block**: 4 conditional declarations

Also replaced deprecated `pow(x, -2)` with `inv_square(x)` at one usage site (Stan 2.33+ deprecation, `err_proc_iid` + `trapezoid` models only).

`inst/models/*.stan` — all 400 generated files regenerated via `mm_generate_mcmc_files()` to reflect the template changes. Body indexing (e.g. `DO_obs[i]`, `GPP_inst[1:n24,j]`) is unchanged throughout — only declarations changed.

### Verification

- **Symmetry check**: 5840 insertions = 5840 deletions across 400 files — confirms pure declaration swap, zero net content drift
- **Dimension-order check**: manually traced `lnQ_bins`/`lnQ_bin_weights` (the one 2D declaration case) through usage sites in the Stan model body and back to the R-side `rbind()` construction in `metab_bayes.R` — confirmed `array[2, d]` ordering is correct
- **Compile check** (6 representative configs spanning all conditional branches):
- **Regression tests**: pre/post numeric comparison against saved baseline `.rds` files — French Creek GPP/ER/K600 deltas consistent with MCMC sampling noise, well within existing `±0.2`/`±3` tolerance vs. Bob Hall MLE reference
- **Full test suite**: 390 pass / 4 skip / 0 fail / 0 warn — identical to pre-fix baseline

### Scope note

This PR is independent of the CmdStanR migration decision. Fixing Stan language syntax is interface-agnostic — it applies equally whether the package stays on rstan or eventually moves to CmdStanR, and does not touch any of the rstan execution/output-parsing code.