### PR TITLE
Fix split_dates=TRUE crash from compile_time in bayes_1ply()

### DIFF
--- a/R/metab_bayes.R
+++ b/R/metab_bayes.R
@@ -178,7 +178,8 @@ metab_bayes <- function(
       {if(!is.null(.)) setNames(., 'Compilation') else .}
       log <- extract_object_list('log') %>% { setNames(., paste0('MCMC_', names(.))) }
       bayes_log <- c(compile_log, log)
-      bayes_compile_time <- bayes_all_list[['compile_time']]
+      compile_times <- extract_object_list('compile_time')
+      bayes_compile_time <- Reduce(`+`, compile_times[!sapply(compile_times, is.null)], system.time({}))
       bayes_mcmc <- extract_object_list('mcmcfit')
       bayes_mcmc_data <- extract_object_list('mcmc_data')
       bayes_all <- list(daily=bayes_daily)
@@ -300,12 +301,12 @@ bayes_1ply <- function(
 
   # package the results, data, warnings, and errors
   outdf <- data.frame(
-    bayes_1day[!(names(bayes_1day) %in% c('mcmcfit','log','compile_log'))],
+    bayes_1day[!(names(bayes_1day) %in% c('mcmcfit','log','compile_log','compile_time'))],
     valid_day=isTRUE(ply_validity),
     warnings=paste0(trimws(unique(warn_strs)), collapse="; "),
     errors=paste0(trimws(unique(stop_strs)), collapse="; "),
     stringsAsFactors=FALSE) %>%
-    mutate(log = list(bayes_1day$log))
+    mutate(log = list(bayes_1day$log), compile_time = list(bayes_1day$compile_time))
 
   # attach the compile_log, mcmcfit, & mcmcdata if requested/available
   if(exists('compile_log', bayes_1day)) outdf$compile_log <- list(bayes_1day$compile_log)

--- a/tests/testthat/test-format_mcmc_mat_split.R
+++ b/tests/testthat/test-format_mcmc_mat_split.R
@@ -1,0 +1,31 @@
+test_that("metab_bayes(split_dates=TRUE) runs end to end and produces the expected predict_metab() shape", {
+  skip_on_cran()
+
+  # split_dates=TRUE requires a pooled K600 model, which in turn requires a
+  # discharge column in the input data.
+  dat <- data_metab('3', '30')
+  dat$discharge <- 3
+  sp <- suppressWarnings(specs(
+    'b_Kl_oi_eu_plrckm.stan', split_dates=TRUE, n_chains=2, n_cores=2,
+    burnin_steps=200, saved_steps=100))
+
+  # 1. metab_bayes() completes without error
+  mm <- metab_bayes(specs=sp, data=dat)
+
+  # 2. predict_metab(mm) returns a data frame with more than 0 rows
+  mp <- predict_metab(mm)
+  expect_true(is.data.frame(mp))
+  expect_gt(nrow(mp), 0)
+
+  # 3. column names for split_dates=TRUE output: predict_metab() produces the
+  # same standardized column set regardless of split_dates, since it's built
+  # from get_fit(mm)$daily via the same predict_metab.metab_bayes code path
+  expect_true(all(c('date','GPP','GPP.lower','GPP.upper','ER','ER.lower','ER.upper') %in% names(mp)))
+
+  # 4. date ordering/structure: 3 consecutive, strictly increasing days with
+  # 1-day gaps, same as the nosplit case
+  expect_equal(nrow(mp), 3)
+  expect_equal(mp$date, as.Date(c('2012-09-18','2012-09-19','2012-09-20')))
+  expect_true(all(diff(mp$date) > 0))
+  expect_equal(as.numeric(diff(mp$date)), c(1, 1))
+})


### PR DESCRIPTION
## Summary

Fixes two bugs in `bayes_1ply()` (`R/metab_bayes.R`) that caused `metab_bayes(..., split_dates=TRUE)` to error.  Both bugs were in the `split_dates=TRUE` — the only `split_dates=TRUE` tests in the repo live inside `manual_test1()`/`manual_test4()` in `test-metab_bayes.R`, which are function definitions that are never called by `devtools::test()`.

## Bug 1 — `compile_time` not stripped before `data.frame()` (~line 303)

`bayes_1ply()` strips `mcmcfit`, `log`, and `compile_log` from the per-day result before building an output row via `data.frame()`, but did not strip `compile_time` — a length-5 `proc_time` object from `system.time()`. Since every other field is length 1, R's `data.frame()` recycled the entire row to 5 rows. Later, `mm_model_by_ply()` builds a 0-row template via `out_list[[i]][FALSE,]`; slicing a `proc_time` column silently drops its class, turning it into a plain double. The subsequent `dplyr::bind_rows()` then fails:

    Error: Can't combine ..1$compile_time <double> and
           ..2$compile_time <proc_time>

**Fix:** Added `compile_time` to the strip list before `data.frame()`, and preserved it as a list-column in the downstream `mutate()` alongside `log`/`compile_log`/`mcmcfit` — matching the existing pattern for those fields.

## Bug 2 — `bayes_all_list` referenced in the `split_dates=TRUE` branch (~line 181)

Fixing Bug 1 allowed `split_dates=TRUE` to get further, which unmasked a second crash: `bayes_compile_time <- bayes_all_list[['compile_time']]` references `bayes_all_list`, a variable only assigned in the `split_dates=FALSE` branch. In the `TRUE` branch it never exists, so this always threw:

    Error: object 'bayes_all_list' not found

**Fix:** Replaced the `bayes_all_list` reference with the same `extract_object_list('compile_time')` + `Reduce(`+`, ...)` pattern
already used in that branch for `log` and `compile_log`. Verified that `+` on `proc_time` objects preserves class and sums correctly.

## Examples that would fail:

```
library(streamMetabolizer)

dat <- data_metab('1', '30')

# b_Kn_oi_eu_plrckm.stan = pool_K600='normal' (pooled but no discharge required),
# err_obs_iid=TRUE, err_proc_iid=FALSE, ode_method='euler', GPP_fun='linlight'
mm <- metab_bayes(
  specs(
    'b_Kn_oi_eu_plrckm.stan',
    split_dates  = TRUE,
    n_chains     = 2,
    n_cores      = 2,
    burnin_steps = 50,
    saved_steps  = 50
  ),
  data = dat
)

dat <- data_metab('3', '30')

mm <- metab_bayes(
  specs(
    'b_Kn_oi_eu_plrckm.stan',
    split_dates  = TRUE,
    n_chains     = 2,
    n_cores      = 2,
    burnin_steps = 50,
    saved_steps  = 50
  ),
  data = dat
)
```

## Tests

Added `tests/testthat/test-format_mcmc_mat_split.R` — a test confirming `metab_bayes()` with `split_dates=TRUE` now completes without error, `predict_metab()` returns a 3-row data frame with the expected columns, and dates are correct consecutive days in strictly increasing order.

Full test suite: 424 pass, 4 skip, 0 fail, 0 warn (prior baseline: 403/4/0/0; delta is 21 new assertions across this and prior PRs).

## Files changed

- `R/metab_bayes.R` — two chunks in `bayes_1ply()`, both in the `split_dates=TRUE` branch
- `tests/testthat/test-format_mcmc_mat_split.R` — new file